### PR TITLE
Add Stakeholder Matrix tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,24 @@
 {
-  "name": "dashboard-design",
+  "name": "heic2jpg",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dashboard-design",
+      "name": "heic2jpg",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "clsx": "^2.0.0",
+        "file-saver": "^2.0.5",
         "heic2any": "^0.0.4",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.294.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-dropzone": "^14.3.8"
+        "react-dropzone": "^14.3.8",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.37",
@@ -303,6 +308,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1087,13 +1145,13 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1429,7 +1487,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -1561,6 +1619,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
     },
     "node_modules/file-selector": {
       "version": "2.1.2",
@@ -1704,6 +1768,12 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
       "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
@@ -2720,6 +2790,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2907,6 +2986,34 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "lucide-react": "^0.294.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-dropzone": "^14.3.8"
+    "react-dropzone": "^14.3.8",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "file-saver": "^2.0.5",
+    "html-to-image": "^1.11.13",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import TextCounter from './components/TextCounter';
 import HeicToJpgConverter from './components/HeicToJpgConverter';
 import PomodoroTimer from './components/PomodoroTimer';
 import PublicIp from './components/PublicIp';
+import StakeholderTool from './components/stakeholder/StakeholderTool';
 
 
 function App() {
@@ -32,6 +33,8 @@ function App() {
                   ? 'Pomodoro Timer'
                   : activeTool === 'ipaddress'
                   ? 'Public IP Address'
+                  : activeTool === 'stakeholders'
+                  ? 'Stakeholder Matrix'
                   : 'coming soon ..'}
               </h1>
               <div className="flex items-center space-x-4">
@@ -50,6 +53,8 @@ function App() {
                 <PomodoroTimer />
               ) : activeTool === 'ipaddress' ? (
                 <PublicIp />
+              ) : activeTool === 'stakeholders' ? (
+                <StakeholderTool />
               ) : null}
             </div>
           </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,8 @@ import {
   HelpCircle,
   ImagePlus,
   Timer,
-  Globe
+  Globe,
+  Sitemap
 } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -74,6 +75,19 @@ function Sidebar({ activeTool, setActiveTool }) {
             >
               <Globe className="w-5 h-5" />
               <span className="font-medium">Public IP</span>
+            </button>
+
+            <button
+              className={clsx(
+                "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
+                activeTool === 'stakeholders'
+                  ? "bg-gray-900 text-white hover:bg-gray-800"
+                  : "text-gray-600 hover:bg-gray-50"
+              )}
+              onClick={() => setActiveTool('stakeholders')}
+            >
+              <Sitemap className="w-5 h-5" />
+              <span className="font-medium">Stakeholder Matrix</span>
             </button>
 
             <button 

--- a/src/components/stakeholder/PersonaCard.jsx
+++ b/src/components/stakeholder/PersonaCard.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { useStakeholderStore } from './store.js';
+
+export default function PersonaCard({ id }) {
+  const card = useStakeholderStore((state) =>
+    state.cards.find((c) => c.id === id)
+  );
+  const updateCard = useStakeholderStore((state) => state.updateCard);
+  const removeCard = useStakeholderStore((state) => state.removeCard);
+
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id });
+
+  const style = {
+    transform: `translate3d(${card.x + (transform?.x || 0)}px, ${
+      card.y + (transform?.y || 0)
+    }px, 0)`,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="persona-card"
+      {...listeners}
+      {...attributes}
+    >
+      <button
+        type="button"
+        className="delete-card-button"
+        onClick={() => removeCard(id)}
+      >
+        ×
+      </button>
+
+      <input
+        className="persona-input"
+        type="text"
+        placeholder="Name"
+        value={card.name}
+        onChange={(e) => updateCard(id, { name: e.target.value })}
+        onPointerDown={(e) => e.stopPropagation()}
+        required
+      />
+      <input
+        className="persona-input"
+        type="text"
+        placeholder="Role / Organisation"
+        value={card.role}
+        onChange={(e) => updateCard(id, { role: e.target.value })}
+        onPointerDown={(e) => e.stopPropagation()}
+      />
+      <textarea
+        className="persona-textarea"
+        placeholder="Why here?"
+        value={card.why}
+        onChange={(e) => updateCard(id, { why: e.target.value })}
+        onPointerDown={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/src/components/stakeholder/StakeholderMatrix.jsx
+++ b/src/components/stakeholder/StakeholderMatrix.jsx
@@ -1,0 +1,39 @@
+import React, { forwardRef } from 'react';
+
+const defaultQuadrants = [
+  'Keep satisfied',
+  'Manage closely',
+  'Monitor',
+  'Keep informed',
+];
+
+const StakeholderMatrix = forwardRef(function StakeholderMatrix(
+  { children, quadrantLabels = defaultQuadrants, xLabel = 'Interest', yLabel = 'Influence', onAddCard },
+  ref
+) {
+  const [tl, tr, bl, br] = quadrantLabels;
+  return (
+    <div ref={ref} className="stakeholder-matrix relative w-full max-w-lg aspect-square mx-auto">
+      <div className="axis-y">
+        <span>{yLabel}</span>
+      </div>
+      <div className="axis-x">
+        <span>{xLabel}</span>
+      </div>
+      <div className="matrix-grid">
+        <div className="cell">{tl}</div>
+        <div className="cell">{tr}</div>
+        <div className="cell">{bl}</div>
+        <div className="cell">{br}</div>
+      </div>
+      {children}
+      {onAddCard && (
+        <button type="button" className="add-card-button" onClick={onAddCard}>
+          +
+        </button>
+      )}
+    </div>
+  );
+});
+
+export default StakeholderMatrix;

--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -1,0 +1,68 @@
+import React, { useRef } from 'react';
+import { DndContext } from '@dnd-kit/core';
+import { createSnapModifier } from '@dnd-kit/modifiers';
+import { toPng } from 'html-to-image';
+import { saveAs } from 'file-saver';
+import StakeholderMatrix from './StakeholderMatrix.jsx';
+import PersonaCard from './PersonaCard.jsx';
+import { useStakeholderStore } from './store.js';
+import './stakeholder.css';
+
+export default function StakeholderTool() {
+  const cards = useStakeholderStore((state) => state.cards);
+  const addCard = useStakeholderStore((state) => state.addCard);
+  const updatePosition = useStakeholderStore((state) => state.updatePosition);
+  const exportRef = useRef();
+
+  const modifiers = [createSnapModifier(40)];
+
+  const handleDragEnd = (event) => {
+    const { delta, active } = event;
+    updatePosition(active.id, delta);
+  };
+
+  const handleExport = () => {
+    if (exportRef.current === null) return;
+    toPng(exportRef.current, { cacheBust: true })
+      .then((dataUrl) => {
+        saveAs(dataUrl, 'stakeholder-matrix.png');
+      })
+      .catch((err) => {
+        console.error('Oops, something went wrong!', err);
+      });
+  };
+
+  return (
+    <div className="app-container">
+      <button type="button" onClick={handleExport} className="export-button">
+        Export as PNG
+      </button>
+      <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
+        <div className="matrix-row" ref={exportRef}>
+          <StakeholderMatrix
+            quadrantLabels={[
+              'Blockers',
+              'Drivers',
+              'Bystanders',
+              'Defenders',
+            ]}
+            onAddCard={() => addCard(2)}
+          >
+            {cards
+              .filter((card) => card.matrixId === 2)
+              .map((card) => (
+                <PersonaCard key={card.id} id={card.id} />
+              ))}
+          </StakeholderMatrix>
+          <StakeholderMatrix onAddCard={() => addCard(1)}>
+            {cards
+              .filter((card) => card.matrixId === 1)
+              .map((card) => (
+                <PersonaCard key={card.id} id={card.id} />
+              ))}
+          </StakeholderMatrix>
+        </div>
+      </DndContext>
+    </div>
+  );
+}

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -1,0 +1,262 @@
+.app-container {
+  background-color: #f9fafb;
+  color: #111827;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  font-family: sans-serif;
+  position: relative;
+}
+
+.export-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.5rem 1.5rem;
+  background-color: #16a34a;
+  border-radius: 6px;
+  font-weight: 600;
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.export-button:hover {
+  background-color: #22c55e;
+}
+
+.matrix-row {
+  display: flex;
+  gap: 2rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.stakeholder-matrix {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+}
+
+.axis-x,
+.axis-y {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  color: #222;
+}
+
+.axis-x::before,
+.axis-x::after,
+.axis-y::before,
+.axis-y::after {
+  content: '';
+  position: absolute;
+}
+
+.axis-x {
+  bottom: -1.5rem;
+  left: 0;
+  right: 0;
+  height: 1rem;
+}
+
+.axis-x::before {
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: #555;
+}
+
+.axis-x::after {
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid #555;
+  border-bottom: 2px solid #555;
+}
+
+.axis-y {
+  top: 0;
+  bottom: 0;
+  left: -1.5rem;
+  width: 1rem;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.axis-y::before {
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: #555;
+}
+
+.axis-y::after {
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 6px;
+  height: 6px;
+  border-top: 2px solid #555;
+  border-right: 2px solid #555;
+}
+
+.matrix-grid {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 2px;
+  background-color: #ddd;
+}
+
+.cell {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 0.5rem;
+  font-weight: bold;
+  font-size: 1.1rem;
+  color: #222;
+  background-color: #f4f7fa;
+  background-clip: padding-box;
+}
+
+.draggable-box {
+  background-color: #3b82f6;
+  color: white;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: grab;
+  touch-action: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.matrix-area {
+  background-image: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 39px,
+      rgba(255, 255, 255, 0.05) 40px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 39px,
+      rgba(255, 255, 255, 0.05) 40px
+    );
+  background-size: 40px 40px;
+}
+
+.matrix-area::before,
+.matrix-area::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.matrix-area::before {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background-image: repeating-linear-gradient(
+    90deg,
+    #475569 0 2px,
+    transparent 2px 40px
+  );
+}
+
+.matrix-area::after {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  background-image: repeating-linear-gradient(
+    180deg,
+    #475569 0 2px,
+    transparent 2px 40px
+  );
+}
+
+.persona-card {
+  background-color: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.5rem;
+  width: 180px;
+  color: #000000;
+  position: absolute;
+  touch-action: none;
+  cursor: grab;
+  z-index: 10;
+}
+
+.persona-input,
+.persona-textarea {
+  width: 100%;
+  margin-bottom: 0.25rem;
+  background-color: #ffffff;
+  color: #000000;
+  font-size: 0.875rem;
+  padding: 0.25rem;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.persona-textarea {
+  resize: vertical;
+  min-height: 40px;
+}
+
+.delete-card-button {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  color: #475569;
+  font-size: 1rem;
+  cursor: pointer;
+  z-index: 20;
+}
+
+.add-card-button {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  background-color: #3b82f6;
+  color: white;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  z-index: 50;
+}
+
+.add-card-button:hover {
+  background-color: #60a5fa;
+}

--- a/src/components/stakeholder/store.js
+++ b/src/components/stakeholder/store.js
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+let idCounter = 0;
+
+export const useStakeholderStore = create((set) => ({
+  cards: [],
+  addCard: (matrixId) =>
+    set((state) => ({
+      cards: [
+        ...state.cards,
+        {
+          id: ++idCounter,
+          matrixId,
+          name: '',
+          role: '',
+          why: '',
+          x: 20,
+          y: 20,
+        },
+      ],
+    })),
+  updateCard: (id, data) =>
+    set((state) => ({
+      cards: state.cards.map((c) => (c.id === id ? { ...c, ...data } : c)),
+    })),
+  updatePosition: (id, delta) =>
+    set((state) => ({
+      cards: state.cards.map((c) =>
+        c.id === id ? { ...c, x: c.x + delta.x, y: c.y + delta.y } : c
+      ),
+    })),
+  removeCard: (id) =>
+    set((state) => ({
+      cards: state.cards.filter((c) => c.id !== id),
+    })),
+}));


### PR DESCRIPTION
## Summary
- add Stakeholder Matrix drag-and-drop tool
- expose tool in sidebar and application header
- include zustand store and DnD kit logic
- update dependencies for new tool

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_b_684b44a52a3c832b9a72e70ba8e8e73d