### PR TITLE
Improve stakeholder matrix layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import Sidebar from './components/Sidebar';
 import TextCounter from './components/TextCounter';
 import HeicToJpgConverter from './components/HeicToJpgConverter';
@@ -21,7 +22,14 @@ function App() {
 
         {/* Main Content */}
         <div className="flex-1 p-8 overflow-y-auto h-screen">
-          <div className="max-w-4xl mx-auto">
+          <div
+            className={
+              clsx(
+                'mx-auto',
+                activeTool === 'stakeholders' ? 'w-2/3 max-w-none' : 'max-w-4xl'
+              )
+            }
+          >
             {/* Header */}
             <div className="flex justify-between items-center mb-8">
               <h1 className="text-xl font-semibold text-gray-900">

--- a/src/components/stakeholder/PersonaCard.jsx
+++ b/src/components/stakeholder/PersonaCard.jsx
@@ -29,6 +29,7 @@ export default function PersonaCard({ id }) {
         type="button"
         className="delete-card-button"
         onClick={() => removeCard(id)}
+        onPointerDown={(e) => e.stopPropagation()}
       >
         ×
       </button>

--- a/src/components/stakeholder/StakeholderMatrix.jsx
+++ b/src/components/stakeholder/StakeholderMatrix.jsx
@@ -13,7 +13,7 @@ const StakeholderMatrix = forwardRef(function StakeholderMatrix(
 ) {
   const [tl, tr, bl, br] = quadrantLabels;
   return (
-    <div ref={ref} className="stakeholder-matrix relative w-full max-w-lg aspect-square mx-auto">
+    <div ref={ref} className="stakeholder-matrix relative w-full aspect-square flex-1">
       <div className="axis-y">
         <span>{yLabel}</span>
       </div>

--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -33,12 +33,9 @@ export default function StakeholderTool() {
   };
 
   return (
-    <div className="app-container">
-      <button type="button" onClick={handleExport} className="export-button">
-        Export as PNG
-      </button>
+    <div className="app-container w-full h-full relative flex flex-col items-center justify-center">
       <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
-        <div className="matrix-row" ref={exportRef}>
+        <div className="matrix-row w-full lg:w-2/3 mx-auto" ref={exportRef}>
           <StakeholderMatrix
             quadrantLabels={[
               'Blockers',
@@ -63,6 +60,9 @@ export default function StakeholderTool() {
           </StakeholderMatrix>
         </div>
       </DndContext>
+      <button type="button" onClick={handleExport} className="export-button">
+        Export as PNG
+      </button>
     </div>
   );
 }

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -14,7 +14,7 @@
 
 .export-button {
   position: absolute;
-  top: 1rem;
+  bottom: 1rem;
   right: 1rem;
   padding: 0.5rem 1.5rem;
   background-color: #16a34a;
@@ -40,9 +40,9 @@
 .stakeholder-matrix {
   position: relative;
   width: 100%;
-  max-width: 600px;
+  max-width: none;
+  flex: 1;
   aspect-ratio: 1 / 1;
-  margin: 0 auto;
 }
 
 .axis-x,


### PR DESCRIPTION
## Summary
- widen container for stakeholder matrix using clsx
- reposition export button at the bottom
- ensure matrices use available width
- prevent dragging when clicking delete

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684b48b94bf0832b975da00ac73ac756