### PR TITLE
Expand stakeholder matrix layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import Sidebar from './components/Sidebar';
 import TextCounter from './components/TextCounter';
 import HeicToJpgConverter from './components/HeicToJpgConverter';
@@ -21,7 +22,14 @@ function App() {
 
         {/* Main Content */}
         <div className="flex-1 p-8 overflow-y-auto h-screen">
-          <div className="max-w-4xl mx-auto">
+          <div
+            className={
+              clsx(
+                'mx-auto',
+                activeTool === 'stakeholders' ? 'w-full max-w-none' : 'max-w-4xl'
+              )
+            }
+          >
             {/* Header */}
             <div className="flex justify-between items-center mb-8">
               <h1 className="text-xl font-semibold text-gray-900">

--- a/src/components/stakeholder/PersonaCard.jsx
+++ b/src/components/stakeholder/PersonaCard.jsx
@@ -28,7 +28,11 @@ export default function PersonaCard({ id }) {
       <button
         type="button"
         className="delete-card-button"
-        onClick={() => removeCard(id)}
+        onClick={(e) => {
+          e.stopPropagation();
+          removeCard(id);
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
       >
         ×
       </button>

--- a/src/components/stakeholder/StakeholderMatrix.jsx
+++ b/src/components/stakeholder/StakeholderMatrix.jsx
@@ -13,7 +13,7 @@ const StakeholderMatrix = forwardRef(function StakeholderMatrix(
 ) {
   const [tl, tr, bl, br] = quadrantLabels;
   return (
-    <div ref={ref} className="stakeholder-matrix relative w-full max-w-lg aspect-square mx-auto">
+    <div ref={ref} className="stakeholder-matrix relative w-full aspect-square flex-1">
       <div className="axis-y">
         <span>{yLabel}</span>
       </div>

--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -33,12 +33,9 @@ export default function StakeholderTool() {
   };
 
   return (
-    <div className="app-container">
-      <button type="button" onClick={handleExport} className="export-button">
-        Export as PNG
-      </button>
+    <div className="app-container w-full h-full relative flex flex-col items-center justify-center">
       <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
-        <div className="matrix-row" ref={exportRef}>
+        <div className="matrix-row w-full" ref={exportRef}>
           <StakeholderMatrix
             quadrantLabels={[
               'Blockers',
@@ -63,6 +60,13 @@ export default function StakeholderTool() {
           </StakeholderMatrix>
         </div>
       </DndContext>
+      <button
+        type="button"
+        onClick={handleExport}
+        className="absolute bottom-4 right-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg shadow-md transition-colors"
+      >
+        Export as PNG
+      </button>
     </div>
   );
 }

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -12,23 +12,6 @@
   position: relative;
 }
 
-.export-button {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  padding: 0.5rem 1.5rem;
-  background-color: #16a34a;
-  border-radius: 6px;
-  font-weight: 600;
-  color: white;
-  border: none;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.export-button:hover {
-  background-color: #22c55e;
-}
 
 .matrix-row {
   display: flex;
@@ -40,9 +23,9 @@
 .stakeholder-matrix {
   position: relative;
   width: 100%;
-  max-width: 600px;
+  max-width: none;
+  flex: 1;
   aspect-ratio: 1 / 1;
-  margin: 0 auto;
 }
 
 .axis-x,


### PR DESCRIPTION
## Summary
- make main container full width when viewing stakeholder tool
- widen matrix row and restyle export button to use Tailwind classes
- stop drag events from interfering with persona delete
- drop unused CSS rules

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b48b94bf0832b975da00ac73ac756