### PR TITLE
Fix Stakeholder matrix layout

### DIFF
--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -35,7 +35,6 @@ export default function StakeholderTool() {
 
   return (
     <div className="app-container w-full h-full relative flex flex-col items-center justify-center">
-      <StakeholderInfo />
       <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
         <div className="matrix-row w-full" ref={exportRef}>
           <StakeholderMatrix
@@ -61,6 +60,7 @@ export default function StakeholderTool() {
           </StakeholderMatrix>
         </div>
       </DndContext>
+      <StakeholderInfo />
       <div className="absolute bottom-4 right-4 flex gap-2">
         <button
           type="button"

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -110,7 +110,7 @@
 .axis-y::after {
   top: 0;
   left: 50%;
-  transform: translateX(-50%) rotate(-135deg);
+  transform: translateX(-50%) rotate(45deg);
   width: 6px;
   height: 6px;
   border: 2px solid #555;


### PR DESCRIPTION
## Summary
- show the stakeholder explanation tables below the matrix
- correct the y‑axis arrow pointing direction

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684b53af83c8832bbe80559ff2eff018