### PR TITLE
Fix persona card keyboard issues

### DIFF
--- a/src/components/stakeholder/PersonaCard.jsx
+++ b/src/components/stakeholder/PersonaCard.jsx
@@ -44,6 +44,7 @@ export default function PersonaCard({ id }) {
         value={card.name}
         onChange={(e) => updateCard(id, { name: e.target.value })}
         onPointerDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
         required
       />
       <input
@@ -53,6 +54,7 @@ export default function PersonaCard({ id }) {
         value={card.role}
         onChange={(e) => updateCard(id, { role: e.target.value })}
         onPointerDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       />
       <textarea
         className="persona-textarea"
@@ -60,6 +62,7 @@ export default function PersonaCard({ id }) {
         value={card.why}
         onChange={(e) => updateCard(id, { why: e.target.value })}
         onPointerDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       />
     </div>
   );

--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { DndContext } from '@dnd-kit/core';
+import { DndContext, useSensor, useSensors, PointerSensor } from '@dnd-kit/core';
 import { createSnapModifier } from '@dnd-kit/modifiers';
 import { toPng } from 'html-to-image';
 import { saveAs } from 'file-saver';
@@ -14,6 +14,8 @@ export default function StakeholderTool() {
   const addCard = useStakeholderStore((state) => state.addCard);
   const updatePosition = useStakeholderStore((state) => state.updatePosition);
   const exportRef = useRef();
+
+  const sensors = useSensors(useSensor(PointerSensor));
 
   const modifiers = [createSnapModifier(40)];
 
@@ -36,7 +38,7 @@ export default function StakeholderTool() {
   return (
     <div className="app-container w-full h-full relative flex flex-col items-center justify-center">
       <StakeholderInfo />
-      <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
         <div className="matrix-row w-full" ref={exportRef}>
           <StakeholderMatrix
             quadrantLabels={[

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -44,6 +44,7 @@
   max-width: none;
   flex: 1;
   aspect-ratio: 1 / 1;
+  overflow: visible;
 }
 
 .axis-x,
@@ -66,14 +67,17 @@
 }
 
 .axis-x {
-  bottom: -1.5rem;
+  bottom: 0;
   left: 0;
   right: 0;
   height: 1rem;
+  transform: translateY(100%);
+  display: flex;
+  flex-direction: column;
 }
 
 .axis-x::before {
-  top: 50%;
+  top: 0;
   left: 0;
   right: 0;
   height: 1px;
@@ -82,7 +86,7 @@
 
 .axis-x::after {
   right: 0;
-  top: 50%;
+  top: 0;
   transform: translateY(-50%) rotate(-45deg);
   width: 6px;
   height: 6px;
@@ -90,17 +94,23 @@
   border-width: 0 2px 2px 0;
 }
 
+.axis-x span {
+  margin-top: 0.25rem;
+}
+
 .axis-y {
   top: 0;
   bottom: 0;
-  left: -1.5rem;
+  left: 0;
   width: 1rem;
   writing-mode: vertical-rl;
-  transform: rotate(180deg);
+  transform: translateX(-100%) rotate(180deg);
+  display: flex;
+  flex-direction: column;
 }
 
 .axis-y::before {
-  left: 50%;
+  left: 0;
   top: 0;
   bottom: 0;
   width: 1px;
@@ -109,12 +119,16 @@
 
 .axis-y::after {
   top: 0;
-  left: 50%;
-  transform: translateX(-50%) rotate(-135deg);
+  left: 0;
+  transform: translate(-50%, 0) rotate(-135deg);
   width: 6px;
   height: 6px;
   border: 2px solid #555;
   border-width: 0 2px 2px 0;
+}
+
+.axis-y span {
+  margin-right: 0.25rem;
 }
 
 .matrix-grid {


### PR DESCRIPTION
## Summary
- add PointerSensor to disable dnd-kit keyboard sensor
- stop key events from propagating out of card inputs
- keep axis labels outside of matrix lines and ensure matrix area overflows visible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684b558b9acc832ba612b3451c103400