### PR TITLE
feat: unify tool styling with shared components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import StakeholderTool from './components/stakeholder/StakeholderTool';
 import OcrTool from './components/ocr/OcrTool';
 import RAGTokenCalculator from './components/RAGTokenCalculator';
 import TokenProductionRateDemo from './components/TokenProductionRateDemo';
+import Card from './components/ui/Card';
 
 
 function App() {
@@ -63,7 +64,7 @@ function App() {
             </div>
 
             {/* Content Card */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <Card>
               {activeTool === 'heic2jpg' ? (
                 <HeicToJpgConverter />
               ) : activeTool === 'textcounter' ? (
@@ -81,7 +82,7 @@ function App() {
               ) : activeTool === 'tokenrate' ? (
                 <TokenProductionRateDemo />
               ) : null}
-            </div>
+            </Card>
           </div>
         </div>
       </div>

--- a/src/components/HeicToJpgConverter.jsx
+++ b/src/components/HeicToJpgConverter.jsx
@@ -133,7 +133,7 @@ export default function HeicToJpgConverter() {
               {...getRootProps()} 
               className={clsx(
                 "border-2 border-dashed rounded-lg p-8 cursor-pointer",
-                isDragActive ? "border-rose-400 bg-rose-50" : "border-gray-200"
+                isDragActive ? "border-primary-400 bg-primary-50" : "border-gray-200"
               )}
             >
               <input {...getInputProps()} accept=".heic,image/heic,image/heif" />
@@ -142,7 +142,7 @@ export default function HeicToJpgConverter() {
                 <p className="text-sm text-gray-500">
                   {isDragActive ? "Drop the files here" : "Click or drag and drop to upload HEIC files"}
                 </p>
-                <button className="text-rose-500 text-sm mt-2">Browse Files</button>
+                <button className="text-primary-500 text-sm mt-2">Browse Files</button>
               </div>
             </div>
           </div>
@@ -183,8 +183,8 @@ export default function HeicToJpgConverter() {
           )}
 
           {/* Convert Button */}
-          <button 
-            className="w-full bg-rose-400 text-white py-3 rounded-lg hover:bg-rose-500 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+          <button
+            className="w-full bg-primary-500 text-white py-3 rounded-lg hover:bg-primary-600 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
             onClick={convertFiles}
             disabled={uploadedFiles.length === 0 || isConverting}
           >

--- a/src/components/PublicIp.jsx
+++ b/src/components/PublicIp.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { RefreshCcw } from 'lucide-react';
+import Button from './ui/Button';
 
 export default function PublicIp() {
   const [ip, setIp] = useState(null);
@@ -29,13 +30,10 @@ export default function PublicIp() {
       <div className="text-gray-700 text-lg">
         {loading ? 'Loading...' : error ? error : ip}
       </div>
-      <button
-        className="flex items-center space-x-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
-        onClick={fetchIp}
-      >
+      <Button className="flex items-center space-x-2" onClick={fetchIp}>
         <RefreshCcw className="w-4 h-4" />
         <span>Refresh</span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/RAGTokenCalculator.jsx
+++ b/src/components/RAGTokenCalculator.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { Calculator, DollarSign, Search, Layers, Zap, BarChart3, ArrowRight } from 'lucide-react';
+import Card from './ui/Card';
 
 const RAGTokenCalculator = () => {
   const [scenario, setScenario] = useState('medium');
@@ -122,10 +123,10 @@ const RAGTokenCalculator = () => {
   };
 
   return (
-    <div className="max-w-7xl mx-auto p-6 bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
+    <div className="space-y-8">
       <div className="mb-8 text-center">
         <div className="flex items-center justify-center gap-3 mb-4">
-          <Calculator className="w-8 h-8 text-blue-600" />
+          <Calculator className="w-8 h-8 text-primary-600" />
           <h1 className="text-3xl font-bold text-gray-800">RAG Pipeline Token & Cost Calculator</h1>
         </div>
         <p className="text-gray-600 max-w-3xl mx-auto">
@@ -135,9 +136,9 @@ const RAGTokenCalculator = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <Card>
             <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-              <Layers className="w-5 h-5 text-blue-600" />
+              <Layers className="w-5 h-5 text-primary-600" />
               Scenario
             </h2>
 
@@ -157,8 +158,8 @@ const RAGTokenCalculator = () => {
                     htmlFor={key}
                     className={`block p-3 border-2 rounded-lg cursor-pointer transition-all ${
                       scenario === key
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-blue-300'
+                        ? 'border-primary-500 bg-primary-50'
+                        : 'border-gray-200 hover:border-primary-300'
                     }`}
                   >
                     <div className="font-medium capitalize text-gray-800 text-sm">{key}</div>
@@ -181,8 +182,8 @@ const RAGTokenCalculator = () => {
                   htmlFor="custom"
                   className={`block p-3 border-2 rounded-lg cursor-pointer transition-all ${
                     scenario === 'custom'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-200 hover:border-blue-300'
+                      ? 'border-primary-500 bg-primary-50'
+                      : 'border-gray-200 hover:border-primary-300'
                   }`}
                 >
                   <div className="font-medium text-gray-800 text-sm">Custom</div>
@@ -202,7 +203,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.userQuery}
                       onChange={(e) => handleCustomChange('userQuery', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Length of user's question/input. Used in Steps 3 & 5. Priced as input tokens.
@@ -215,7 +216,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.chunkSize}
                       onChange={(e) => handleCustomChange('chunkSize', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Average tokens per document chunk. Multiplied by N chunks for reranking, by Top-K for final RAG.
@@ -228,7 +229,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.numChunks}
                       onChange={(e) => handleCustomChange('numChunks', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Total chunks from vector search sent to reranker. Used in Step 3 reranking prompt (input cost).
@@ -241,7 +242,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.topKChunks}
                       onChange={(e) => handleCustomChange('topKChunks', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Best chunks selected by reranker for final answer. Used in Step 5 RAG prompt (input cost).
@@ -254,7 +255,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.reRankOverhead}
                       onChange={(e) => handleCustomChange('reRankOverhead', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Reranking system prompt and instructions. Added to Step 3 reranking prompt (input cost).
@@ -267,7 +268,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.reRankOutputTokens}
                       onChange={(e) => handleCustomChange('reRankOutputTokens', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Reranker's response with top-K chunk IDs/scores. Step 4 output (output cost).
@@ -280,7 +281,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.ragSystemPrompt}
                       onChange={(e) => handleCustomChange('ragSystemPrompt', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Instructions for final answer generation. Added to Step 5 RAG prompt (input cost).
@@ -293,7 +294,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.finalAnswerTokens}
                       onChange={(e) => handleCustomChange('finalAnswerTokens', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Length of generated response to user. Step 6 output (output cost).
@@ -316,7 +317,7 @@ const RAGTokenCalculator = () => {
                     step="0.01"
                     value={customValues.inputTokenPrice}
                     onChange={(e) => handleCustomChange('inputTokenPrice', e.target.value)}
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   />
                   <div className="text-xs text-gray-500 mt-1">
                     Cost per million input tokens. Applied to Steps 3 & 5 (reranking and RAG prompts).
@@ -329,7 +330,7 @@ const RAGTokenCalculator = () => {
                     step="0.01"
                     value={customValues.outputTokenPrice}
                     onChange={(e) => handleCustomChange('outputTokenPrice', e.target.value)}
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   />
                   <div className="text-xs text-gray-500 mt-1">
                     Cost per million output tokens. Applied to Steps 4 & 6 (reranker response and final answer).
@@ -337,27 +338,27 @@ const RAGTokenCalculator = () => {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         </div>
 
         <div className="lg:col-span-3 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <Card>
             <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
               <Zap className="w-5 h-5 text-green-600" />
               RAG Pipeline Steps & Costs
             </h2>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-primary-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
+                  <div className="w-8 h-8 bg-primary-600 text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
                   <div>
                     <span className="font-medium">User Query Input</span>
                     <div className="text-sm text-gray-600">Initial query from user</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-blue-600">{calculations.step1_Query.toLocaleString()} tokens</div>
+                  <div className="text-lg font-semibold text-primary-600">{calculations.step1_Query.toLocaleString()} tokens</div>
                   <div className="text-sm text-gray-500">No cost (stored)</div>
                 </div>
               </div>
@@ -432,51 +433,51 @@ const RAGTokenCalculator = () => {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white rounded-xl shadow-lg p-6">
-              <h3 className="text-lg font-semibold mb-4 text-gray-800">Token Summary</h3>
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Total Input Tokens:</span>
-                  <span className="font-semibold">{calculations.totalInputTokens.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Total Output Tokens:</span>
-                  <span className="font-semibold">{calculations.totalOutputTokens.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between pt-2 border-t">
-                  <span className="text-gray-800 font-medium">Total Tokens:</span>
-                  <span className="font-bold text-lg">{calculations.totalTokens.toLocaleString()}</span>
-                </div>
+          <Card>
+            <h3 className="text-lg font-semibold mb-4 text-gray-800">Token Summary</h3>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Total Input Tokens:</span>
+                <span className="font-semibold">{calculations.totalInputTokens.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Total Output Tokens:</span>
+                <span className="font-semibold">{calculations.totalOutputTokens.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between pt-2 border-t">
+                <span className="text-gray-800 font-medium">Total Tokens:</span>
+                <span className="font-bold text-lg">{calculations.totalTokens.toLocaleString()}</span>
               </div>
             </div>
+          </Card>
 
-            <div className="bg-white rounded-xl shadow-lg p-6">
-              <h3 className="text-lg font-semibold mb-4 text-gray-800 flex items-center gap-2">
-                <DollarSign className="w-5 h-5 text-green-600" />
-                Cost Breakdown
-              </h3>
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Input Costs (Steps 3+5):</span>
-                  <span className="font-semibold">${calculations.totalInputCost.toFixed(6)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Output Costs (Steps 4+6):</span>
-                  <span className="font-semibold">${calculations.totalOutputCost.toFixed(6)}</span>
-                </div>
-                <div className="flex justify-between pt-2 border-t">
-                  <span className="text-gray-800 font-medium">Total Cost per Query:</span>
-                  <span className="font-bold text-lg text-green-600">${calculations.totalCost.toFixed(6)}</span>
-                </div>
+          <Card>
+            <h3 className="text-lg font-semibold mb-4 text-gray-800 flex items-center gap-2">
+              <DollarSign className="w-5 h-5 text-green-600" />
+              Cost Breakdown
+            </h3>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Input Costs (Steps 3+5):</span>
+                <span className="font-semibold">${calculations.totalInputCost.toFixed(6)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Output Costs (Steps 4+6):</span>
+                <span className="font-semibold">${calculations.totalOutputCost.toFixed(6)}</span>
+              </div>
+              <div className="flex justify-between pt-2 border-t">
+                <span className="text-gray-800 font-medium">Total Cost per Query:</span>
+                <span className="font-bold text-lg text-green-600">${calculations.totalCost.toFixed(6)}</span>
               </div>
             </div>
-          </div>
+          </Card>
+        </div>
 
-          <div className="bg-white rounded-xl shadow-lg p-6">
-            <h3 className="text-lg font-semibold mb-4 text-gray-800">Volume Projections</h3>
+        <Card>
+          <h3 className="text-lg font-semibold mb-4 text-gray-800">Volume Projections</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               {[
                 { queries: 100, period: '100 queries' },
@@ -486,7 +487,7 @@ const RAGTokenCalculator = () => {
               ].map(({ queries, period }) => (
                 <div key={queries} className="p-4 bg-gray-50 rounded-lg text-center">
                   <div className="text-sm text-gray-600 mb-1">{period}</div>
-                  <div className="text-xl font-bold text-blue-600">
+                  <div className="text-xl font-bold text-primary-600">
                     ${(calculations.totalCost * queries).toFixed(2)}
                   </div>
                   <div className="text-xs text-gray-500 mt-1">
@@ -495,7 +496,7 @@ const RAGTokenCalculator = () => {
                 </div>
               ))}
             </div>
-          </div>
+          </Card>
         </div>
       </div>
     </div>

--- a/src/components/TokenProductionRateDemo.jsx
+++ b/src/components/TokenProductionRateDemo.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 const loremWords = [
   'Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing', 'elit',
@@ -110,14 +112,14 @@ export default function TokenProductionRateDemo() {
   const progress = tokens.length > 0 ? ((tokensGenerated / tokens.length) * 100).toFixed(1) : 0;
 
   return (
-    <div className="font-mono text-black space-y-8">
+    <div className="space-y-8">
       <div className="text-center">
-        <h2 className="text-2xl font-bold border-b-2 border-black pb-4">Token Production Rate Demo</h2>
+        <h2 className="text-2xl font-bold text-gray-800">Token Production Rate Demo</h2>
       </div>
 
-      <div className="border-2 border-black p-6 bg-gray-50">
-        <h3 className="font-bold mb-4">📖 Human Reading Speed Reference</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+      <Card className="bg-gray-50">
+        <h3 className="font-semibold mb-4">📖 Human Reading Speed Reference</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700">
           <div>
             <p className="mb-1"><strong>Average Reading Speed:</strong> 200-300 words/minute</p>
             <p className="mb-1"><strong>Speed Readers:</strong> 400-700 words/minute</p>
@@ -129,9 +131,9 @@ export default function TokenProductionRateDemo() {
             <p><strong>Beyond Human:</strong> 20+ tokens/sec</p>
           </div>
         </div>
-      </div>
+      </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 border-2 border-black p-6">
+      <Card className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
           <label htmlFor="textLength" className="block text-xs font-bold uppercase tracking-wide mb-2">
             Text Length: <span>{textLength}</span> words
@@ -162,54 +164,40 @@ export default function TokenProductionRateDemo() {
             className="w-full"
           />
         </div>
-      </div>
-
+      </Card>
       <div className="flex justify-center flex-wrap gap-4">
-        <button
-          className="px-6 py-2 border-2 border-black bg-black text-white font-bold uppercase tracking-wide hover:bg-white hover:text-black disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={startGeneration}
-          disabled={isGenerating}
-        >
-          Start
-        </button>
-        <button
-          className="px-6 py-2 border-2 border-black font-bold uppercase tracking-wide hover:bg-black hover:text-white disabled:opacity-50"
-          onClick={stopGeneration}
-          disabled={!isGenerating}
-        >
+        <Button onClick={startGeneration} disabled={isGenerating}>Start</Button>
+        <Button onClick={stopGeneration} disabled={!isGenerating} className="bg-white text-primary-600 border border-primary-600 hover:bg-primary-50">
           Stop
-        </button>
-        <button
-          className="px-6 py-2 border-2 border-black font-bold uppercase tracking-wide hover:bg-black hover:text-white"
-          onClick={resetDemo}
-        >
+        </Button>
+        <Button onClick={resetDemo} className="bg-white text-primary-600 border border-primary-600 hover:bg-primary-50">
           Reset
-        </button>
+        </Button>
       </div>
 
-      <div className="bg-black text-white p-6 border-2 border-black min-h-[300px] text-sm leading-relaxed overflow-y-auto">
+      <Card className="min-h-[300px] text-sm leading-relaxed overflow-y-auto bg-gray-50">
         {outputTokens.map((t, i) => (
           <span key={i}>{(i > 0 ? ' ' : '') + t}</span>
         ))}
-        {isGenerating && <span className="bg-white text-black px-1 ml-1 animate-pulse">|</span>}
-      </div>
+        {isGenerating && <span className="text-primary-600 px-1 ml-1 animate-pulse">|</span>}
+      </Card>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{tokensGenerated}</div>
-          <div className="text-xs uppercase tracking-wide">Tokens Generated</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Tokens Generated</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{currentSpeed}</div>
-          <div className="text-xs uppercase tracking-wide">Current Speed (T/S)</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Current Speed (T/S)</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{timeElapsed.toFixed(1)}s</div>
-          <div className="text-xs uppercase tracking-wide">Time Elapsed</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Time Elapsed</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{progress}%</div>
-          <div className="text-xs uppercase tracking-wide">Progress</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Progress</div>
         </div>
       </div>
     </div>

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Button({ className, ...props }) {
+  return (
+    <button
+      className={clsx(
+        'px-4 py-2 rounded-lg bg-primary-500 text-white hover:bg-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Card({ className, ...props }) {
+  return (
+    <div
+      className={clsx(
+        'bg-white border border-gray-200 rounded-xl p-6 shadow-card',
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply font-sans text-neutral-800 bg-neutral-50;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,24 @@
 /** @type {import('tailwindcss').Config} */
+import colors from 'tailwindcss/colors'
+
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: colors.rose,
+        neutral: colors.gray,
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+      boxShadow: {
+        card: '0 1px 2px rgba(0,0,0,0.05)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind with design tokens for primary rose accent, neutral palette, font and card shadow
- add shared `Button` and `Card` components and wrap all tool content with them
- harmonize existing tools like HEIC converter, Public IP, RAG calculator and token rate demo to use shared styling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689277a18d28832bbdd400e2ea9b6e31