### PR TITLE
feat: unify tools with black and white theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import StakeholderTool from './components/stakeholder/StakeholderTool';
 import OcrTool from './components/ocr/OcrTool';
 import RAGTokenCalculator from './components/RAGTokenCalculator';
 import TokenProductionRateDemo from './components/TokenProductionRateDemo';
+import Card from './components/ui/Card';
 
 
 function App() {
@@ -19,7 +20,7 @@ function App() {
 
   
   return (
-    <div className="min-h-screen bg-gray-50 overflow-hidden">
+    <div className="min-h-screen bg-white overflow-hidden">
       <div className="flex h-screen">
         <Sidebar activeTool={activeTool} setActiveTool={setActiveTool} />
 
@@ -37,7 +38,7 @@ function App() {
           >
             {/* Header */}
             <div className="flex justify-between items-center mb-8">
-              <h1 className="text-xl font-semibold text-gray-900">
+              <h1 className="text-xl font-semibold text-black">
                 {activeTool === 'heic2jpg'
                   ? 'HEIC to JPG Converter'
                   : activeTool === 'textcounter'
@@ -63,7 +64,7 @@ function App() {
             </div>
 
             {/* Content Card */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <Card>
               {activeTool === 'heic2jpg' ? (
                 <HeicToJpgConverter />
               ) : activeTool === 'textcounter' ? (
@@ -81,7 +82,7 @@ function App() {
               ) : activeTool === 'tokenrate' ? (
                 <TokenProductionRateDemo />
               ) : null}
-            </div>
+            </Card>
           </div>
         </div>
       </div>

--- a/src/components/HeicToJpgConverter.jsx
+++ b/src/components/HeicToJpgConverter.jsx
@@ -3,6 +3,7 @@ import { useDropzone } from 'react-dropzone';
 import heic2any from 'heic2any';
 import { FileImage, Download, Trash } from 'lucide-react';
 import clsx from 'clsx';
+import Button from './ui/Button';
 
 export default function HeicToJpgConverter() {
   const [activeTab, setActiveTab] = useState('upload');
@@ -129,20 +130,20 @@ export default function HeicToJpgConverter() {
             <label className="block text-sm font-medium text-gray-700 mb-2">
               Drop your HEIC files here
             </label>
-            <div 
-              {...getRootProps()} 
-              className={clsx(
-                "border-2 border-dashed rounded-lg p-8 cursor-pointer",
-                isDragActive ? "border-rose-400 bg-rose-50" : "border-gray-200"
-              )}
-            >
+              <div
+                {...getRootProps()}
+                className={clsx(
+                  "border-2 border-dashed rounded-lg p-8 cursor-pointer",
+                  isDragActive ? "border-black bg-gray-50" : "border-black"
+                )}
+              >
               <input {...getInputProps()} accept=".heic,image/heic,image/heif" />
               <div className="text-center">
                 <FileImage className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                <p className="text-sm text-gray-500">
-                  {isDragActive ? "Drop the files here" : "Click or drag and drop to upload HEIC files"}
-                </p>
-                <button className="text-rose-500 text-sm mt-2">Browse Files</button>
+                  <p className="text-sm text-gray-500">
+                    {isDragActive ? "Drop the files here" : "Click or drag and drop to upload HEIC files"}
+                  </p>
+                  <button className="text-black text-sm mt-2">Browse Files</button>
               </div>
             </div>
           </div>
@@ -159,20 +160,20 @@ export default function HeicToJpgConverter() {
                       <span className="text-sm text-gray-700">{file.name}</span>
                     </div>
                     <div className="flex items-center">
-                      {processingFiles.includes(index) && (
-                        <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full mr-2 animate-pulse">
-                          Processing...
-                        </span>
-                      )}
-                      {processedFiles.includes(index) && (
-                        <span className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded-full mr-2">
-                          Done
-                        </span>
-                      )}
+                        {processingFiles.includes(index) && (
+                          <span className="text-xs bg-gray-200 text-gray-800 px-2 py-1 rounded-full mr-2 animate-pulse">
+                            Processing...
+                          </span>
+                        )}
+                        {processedFiles.includes(index) && (
+                          <span className="text-xs bg-gray-200 text-gray-800 px-2 py-1 rounded-full mr-2">
+                            Done
+                          </span>
+                        )}
                       <button 
                         onClick={() => removeUploadedFile(index)}
-                        className="text-gray-400 hover:text-red-500"
-                      >
+                          className="text-gray-400 hover:text-black"
+                        >
                         <Trash className="w-4 h-4" />
                       </button>
                     </div>
@@ -183,13 +184,13 @@ export default function HeicToJpgConverter() {
           )}
 
           {/* Convert Button */}
-          <button 
-            className="w-full bg-rose-400 text-white py-3 rounded-lg hover:bg-rose-500 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
-            onClick={convertFiles}
-            disabled={uploadedFiles.length === 0 || isConverting}
-          >
-            {isConverting ? "Converting..." : "Convert to JPG"}
-          </button>
+            <Button
+              className="w-full"
+              onClick={convertFiles}
+              disabled={uploadedFiles.length === 0 || isConverting}
+            >
+              {isConverting ? "Converting..." : "Convert to JPG"}
+            </Button>
         </>
       ) : (
         <>
@@ -204,33 +205,30 @@ export default function HeicToJpgConverter() {
                       <span className="text-sm text-gray-700">{file.name}</span>
                     </div>
                     <div className="flex space-x-2">
-                      <button 
-                        onClick={() => downloadFile(file)}
-                        className="text-gray-400 hover:text-blue-500"
-                      >
-                        <Download className="w-4 h-4" />
-                      </button>
-                      <button 
-                        onClick={() => removeConvertedFile(index)}
-                        className="text-gray-400 hover:text-red-500"
-                      >
-                        <Trash className="w-4 h-4" />
-                      </button>
+                        <button
+                          onClick={() => downloadFile(file)}
+                          className="text-gray-400 hover:text-black"
+                        >
+                          <Download className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => removeConvertedFile(index)}
+                          className="text-gray-400 hover:text-black"
+                        >
+                          <Trash className="w-4 h-4" />
+                        </button>
                     </div>
                   </div>
                 ))}
               </div>
               
               {/* Download All Button */}
-              <div className="mt-6 flex justify-center">
-                <button 
-                  onClick={downloadAllFiles}
-                  className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 shadow-md transition-colors"
-                >
-                  <Download className="w-4 h-4" />
-                  <span>Download All</span>
-                </button>
-              </div>
+                <div className="mt-6 flex justify-center">
+                  <Button onClick={downloadAllFiles} className="flex items-center space-x-2 shadow-md">
+                    <Download className="w-4 h-4" />
+                    <span>Download All</span>
+                  </Button>
+                </div>
             </>
           ) : (
             <div className="text-center py-8">

--- a/src/components/PomodoroTimer.jsx
+++ b/src/components/PomodoroTimer.jsx
@@ -60,7 +60,7 @@ export default function PomodoroTimer() {
     <div className="flex flex-col h-full items-center justify-center space-y-8">
       <div className="flex space-x-4 mb-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Work Duration (min)</label>
+          <label className="block text-sm font-medium text-black mb-1">Work Duration (min)</label>
           <input
             type="number"
             min="1"
@@ -71,7 +71,7 @@ export default function PomodoroTimer() {
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Break Duration (min)</label>
+          <label className="block text-sm font-medium text-black mb-1">Break Duration (min)</label>
           <input
             type="number"
             min="1"
@@ -83,10 +83,10 @@ export default function PomodoroTimer() {
         </div>
       </div>
       <div className="text-center">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-2">
+        <h2 className="text-2xl font-semibold text-black mb-2">
           {isWorkTime ? 'Work Time' : 'Break Time'}
         </h2>
-        <div className="text-6xl font-bold text-gray-800 mb-8">
+        <div className="text-6xl font-bold text-black mb-8">
           {formatTime(timeLeft)}
         </div>
       </div>
@@ -94,7 +94,7 @@ export default function PomodoroTimer() {
       <div className="flex space-x-4">
         <button
           onClick={handleStartPause}
-          className="flex items-center space-x-2 px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+          className="flex items-center space-x-2 px-6 py-3 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors"
         >
           {isRunning ? (
             <>

--- a/src/components/PublicIp.jsx
+++ b/src/components/PublicIp.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { RefreshCcw } from 'lucide-react';
+import Button from './ui/Button';
 
 export default function PublicIp() {
   const [ip, setIp] = useState(null);
@@ -26,16 +27,13 @@ export default function PublicIp() {
 
   return (
     <div className="flex flex-col items-center justify-center space-y-4">
-      <div className="text-gray-700 text-lg">
+      <div className="text-lg">
         {loading ? 'Loading...' : error ? error : ip}
       </div>
-      <button
-        className="flex items-center space-x-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
-        onClick={fetchIp}
-      >
+      <Button className="flex items-center space-x-2" onClick={fetchIp}>
         <RefreshCcw className="w-4 h-4" />
         <span>Refresh</span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/RAGTokenCalculator.jsx
+++ b/src/components/RAGTokenCalculator.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { Calculator, DollarSign, Search, Layers, Zap, BarChart3, ArrowRight } from 'lucide-react';
+import Card from './ui/Card';
 
 const RAGTokenCalculator = () => {
   const [scenario, setScenario] = useState('medium');
@@ -122,10 +123,10 @@ const RAGTokenCalculator = () => {
   };
 
   return (
-    <div className="max-w-7xl mx-auto p-6 bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
+    <div className="space-y-8">
       <div className="mb-8 text-center">
         <div className="flex items-center justify-center gap-3 mb-4">
-          <Calculator className="w-8 h-8 text-blue-600" />
+          <Calculator className="w-8 h-8 text-black" />
           <h1 className="text-3xl font-bold text-gray-800">RAG Pipeline Token & Cost Calculator</h1>
         </div>
         <p className="text-gray-600 max-w-3xl mx-auto">
@@ -135,9 +136,9 @@ const RAGTokenCalculator = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <Card>
             <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-              <Layers className="w-5 h-5 text-blue-600" />
+              <Layers className="w-5 h-5 text-black" />
               Scenario
             </h2>
 
@@ -157,8 +158,8 @@ const RAGTokenCalculator = () => {
                     htmlFor={key}
                     className={`block p-3 border-2 rounded-lg cursor-pointer transition-all ${
                       scenario === key
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-blue-300'
+                        ? 'border-black bg-gray-50'
+                        : 'border-gray-200 hover:border-black'
                     }`}
                   >
                     <div className="font-medium capitalize text-gray-800 text-sm">{key}</div>
@@ -181,8 +182,8 @@ const RAGTokenCalculator = () => {
                   htmlFor="custom"
                   className={`block p-3 border-2 rounded-lg cursor-pointer transition-all ${
                     scenario === 'custom'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-200 hover:border-blue-300'
+                      ? 'border-black bg-gray-50'
+                      : 'border-gray-200 hover:border-black'
                   }`}
                 >
                   <div className="font-medium text-gray-800 text-sm">Custom</div>
@@ -202,7 +203,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.userQuery}
                       onChange={(e) => handleCustomChange('userQuery', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Length of user's question/input. Used in Steps 3 & 5. Priced as input tokens.
@@ -215,7 +216,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.chunkSize}
                       onChange={(e) => handleCustomChange('chunkSize', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Average tokens per document chunk. Multiplied by N chunks for reranking, by Top-K for final RAG.
@@ -228,7 +229,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.numChunks}
                       onChange={(e) => handleCustomChange('numChunks', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Total chunks from vector search sent to reranker. Used in Step 3 reranking prompt (input cost).
@@ -241,7 +242,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.topKChunks}
                       onChange={(e) => handleCustomChange('topKChunks', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Best chunks selected by reranker for final answer. Used in Step 5 RAG prompt (input cost).
@@ -254,7 +255,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.reRankOverhead}
                       onChange={(e) => handleCustomChange('reRankOverhead', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Reranking system prompt and instructions. Added to Step 3 reranking prompt (input cost).
@@ -267,7 +268,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.reRankOutputTokens}
                       onChange={(e) => handleCustomChange('reRankOutputTokens', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Reranker's response with top-K chunk IDs/scores. Step 4 output (output cost).
@@ -280,7 +281,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.ragSystemPrompt}
                       onChange={(e) => handleCustomChange('ragSystemPrompt', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Instructions for final answer generation. Added to Step 5 RAG prompt (input cost).
@@ -293,7 +294,7 @@ const RAGTokenCalculator = () => {
                       type="number"
                       value={customValues.finalAnswerTokens}
                       onChange={(e) => handleCustomChange('finalAnswerTokens', e.target.value)}
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                     />
                     <div className="text-xs text-gray-500 mt-1">
                       Length of generated response to user. Step 6 output (output cost).
@@ -316,7 +317,7 @@ const RAGTokenCalculator = () => {
                     step="0.01"
                     value={customValues.inputTokenPrice}
                     onChange={(e) => handleCustomChange('inputTokenPrice', e.target.value)}
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                   />
                   <div className="text-xs text-gray-500 mt-1">
                     Cost per million input tokens. Applied to Steps 3 & 5 (reranking and RAG prompts).
@@ -329,7 +330,7 @@ const RAGTokenCalculator = () => {
                     step="0.01"
                     value={customValues.outputTokenPrice}
                     onChange={(e) => handleCustomChange('outputTokenPrice', e.target.value)}
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-black focus:border-transparent"
                   />
                   <div className="text-xs text-gray-500 mt-1">
                     Cost per million output tokens. Applied to Steps 4 & 6 (reranker response and final answer).
@@ -337,34 +338,34 @@ const RAGTokenCalculator = () => {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         </div>
 
         <div className="lg:col-span-3 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <Card>
             <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
-              <Zap className="w-5 h-5 text-green-600" />
+              <Zap className="w-5 h-5 text-black" />
               RAG Pipeline Steps & Costs
             </h2>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
                   <div>
                     <span className="font-medium">User Query Input</span>
                     <div className="text-sm text-gray-600">Initial query from user</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-blue-600">{calculations.step1_Query.toLocaleString()} tokens</div>
+                  <div className="text-lg font-semibold text-black">{calculations.step1_Query.toLocaleString()} tokens</div>
                   <div className="text-sm text-gray-500">No cost (stored)</div>
                 </div>
               </div>
 
               <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gray-600 text-white rounded-full flex items-center justify-center text-sm font-bold">2</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">2</div>
                   <div>
                     <span className="font-medium">Retriever Returns N Chunks</span>
                     <div className="text-sm text-gray-600">Vector search retrieves candidate chunks</div>
@@ -376,107 +377,107 @@ const RAGTokenCalculator = () => {
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-yellow-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-yellow-600 text-white rounded-full flex items-center justify-center text-sm font-bold">3</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">3</div>
                   <div>
                     <span className="font-medium">Reranker Prompt</span>
                     <div className="text-sm text-gray-600">Query + All chunks + instructions</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-yellow-600">{calculations.step3_PromptRerank.toLocaleString()} tokens</div>
-                  <div className="text-sm text-green-600 font-medium">${calculations.step3_Cost.toFixed(6)} (input)</div>
+                  <div className="text-lg font-semibold text-black">{calculations.step3_PromptRerank.toLocaleString()} tokens</div>
+                  <div className="text-sm text-black font-medium">${calculations.step3_Cost.toFixed(6)} (input)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-orange-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-orange-600 text-white rounded-full flex items-center justify-center text-sm font-bold">4</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">4</div>
                   <div>
                     <span className="font-medium">Reranker Output</span>
                     <div className="text-sm text-gray-600">Top-K chunk IDs or rankings</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-orange-600">{calculations.step4_OutputRerank.toLocaleString()} tokens</div>
-                  <div className="text-sm text-green-600 font-medium">${calculations.step4_Cost.toFixed(6)} (output)</div>
+                  <div className="text-lg font-semibold text-black">{calculations.step4_OutputRerank.toLocaleString()} tokens</div>
+                  <div className="text-sm text-black font-medium">${calculations.step4_Cost.toFixed(6)} (output)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-green-600 text-white rounded-full flex items-center justify-center text-sm font-bold">5</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">5</div>
                   <div>
                     <span className="font-medium">Final RAG Prompt</span>
                     <div className="text-sm text-gray-600">Query + Top-K chunks + system prompt</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-green-600">{calculations.step5_PromptRAG.toLocaleString()} tokens</div>
-                  <div className="text-sm text-green-600 font-medium">${calculations.step5_Cost.toFixed(6)} (input)</div>
+                  <div className="text-lg font-semibold text-black">{calculations.step5_PromptRAG.toLocaleString()} tokens</div>
+                  <div className="text-sm text-black font-medium">${calculations.step5_Cost.toFixed(6)} (input)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-purple-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-purple-600 text-white rounded-full flex items-center justify-center text-sm font-bold">6</div>
+                  <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center text-sm font-bold">6</div>
                   <div>
                     <span className="font-medium">Model Output (Answer)</span>
                     <div className="text-sm text-gray-600">Final generated response</div>
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-lg font-semibold text-purple-600">{calculations.step6_OutputAnswer.toLocaleString()} tokens</div>
-                  <div className="text-sm text-green-600 font-medium">${calculations.step6_Cost.toFixed(6)} (output)</div>
+                  <div className="text-lg font-semibold text-black">{calculations.step6_OutputAnswer.toLocaleString()} tokens</div>
+                  <div className="text-sm text-black font-medium">${calculations.step6_Cost.toFixed(6)} (output)</div>
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white rounded-xl shadow-lg p-6">
-              <h3 className="text-lg font-semibold mb-4 text-gray-800">Token Summary</h3>
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Total Input Tokens:</span>
-                  <span className="font-semibold">{calculations.totalInputTokens.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Total Output Tokens:</span>
-                  <span className="font-semibold">{calculations.totalOutputTokens.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between pt-2 border-t">
-                  <span className="text-gray-800 font-medium">Total Tokens:</span>
-                  <span className="font-bold text-lg">{calculations.totalTokens.toLocaleString()}</span>
-                </div>
+          <Card>
+            <h3 className="text-lg font-semibold mb-4 text-gray-800">Token Summary</h3>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Total Input Tokens:</span>
+                <span className="font-semibold">{calculations.totalInputTokens.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Total Output Tokens:</span>
+                <span className="font-semibold">{calculations.totalOutputTokens.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between pt-2 border-t">
+                <span className="text-gray-800 font-medium">Total Tokens:</span>
+                <span className="font-bold text-lg">{calculations.totalTokens.toLocaleString()}</span>
               </div>
             </div>
+          </Card>
 
-            <div className="bg-white rounded-xl shadow-lg p-6">
-              <h3 className="text-lg font-semibold mb-4 text-gray-800 flex items-center gap-2">
-                <DollarSign className="w-5 h-5 text-green-600" />
-                Cost Breakdown
-              </h3>
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Input Costs (Steps 3+5):</span>
-                  <span className="font-semibold">${calculations.totalInputCost.toFixed(6)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Output Costs (Steps 4+6):</span>
-                  <span className="font-semibold">${calculations.totalOutputCost.toFixed(6)}</span>
-                </div>
-                <div className="flex justify-between pt-2 border-t">
-                  <span className="text-gray-800 font-medium">Total Cost per Query:</span>
-                  <span className="font-bold text-lg text-green-600">${calculations.totalCost.toFixed(6)}</span>
-                </div>
+          <Card>
+            <h3 className="text-lg font-semibold mb-4 text-gray-800 flex items-center gap-2">
+              <DollarSign className="w-5 h-5 text-black" />
+              Cost Breakdown
+            </h3>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Input Costs (Steps 3+5):</span>
+                <span className="font-semibold">${calculations.totalInputCost.toFixed(6)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">Output Costs (Steps 4+6):</span>
+                <span className="font-semibold">${calculations.totalOutputCost.toFixed(6)}</span>
+              </div>
+              <div className="flex justify-between pt-2 border-t">
+                <span className="text-gray-800 font-medium">Total Cost per Query:</span>
+                <span className="font-bold text-lg text-black">${calculations.totalCost.toFixed(6)}</span>
               </div>
             </div>
-          </div>
+          </Card>
+        </div>
 
-          <div className="bg-white rounded-xl shadow-lg p-6">
-            <h3 className="text-lg font-semibold mb-4 text-gray-800">Volume Projections</h3>
+        <Card>
+          <h3 className="text-lg font-semibold mb-4 text-gray-800">Volume Projections</h3>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               {[
                 { queries: 100, period: '100 queries' },
@@ -486,7 +487,7 @@ const RAGTokenCalculator = () => {
               ].map(({ queries, period }) => (
                 <div key={queries} className="p-4 bg-gray-50 rounded-lg text-center">
                   <div className="text-sm text-gray-600 mb-1">{period}</div>
-                  <div className="text-xl font-bold text-blue-600">
+                  <div className="text-xl font-bold text-black">
                     ${(calculations.totalCost * queries).toFixed(2)}
                   </div>
                   <div className="text-xs text-gray-500 mt-1">
@@ -495,7 +496,7 @@ const RAGTokenCalculator = () => {
                 </div>
               ))}
             </div>
-          </div>
+          </Card>
         </div>
       </div>
     </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -19,10 +19,10 @@ function Sidebar({ activeTool, setActiveTool }) {
         {/* User Profile */}
         <div className="p-4">
           <div className="flex items-center space-x-2 mb-8 cursor-pointer hover:bg-gray-50 p-2 rounded-lg">
-            <div className="w-8 h-8 bg-rose-500 rounded-lg flex items-center justify-center overflow-hidden">
+            <div className="w-8 h-8 bg-black rounded-lg flex items-center justify-center overflow-hidden">
               <img src="./Marc.jpeg" alt="Marc" className="w-full h-full object-cover" />
             </div>
-            <span className="text-gray-700 font-medium flex-1">Helpful Tools</span>
+            <span className="text-black font-medium flex-1">Helpful Tools</span>
           </div>
 
           {/* Navigation */}

--- a/src/components/TextCounter.jsx
+++ b/src/components/TextCounter.jsx
@@ -18,7 +18,7 @@ export default function TextCounter() {
 
   return (
     <div className="flex flex-col h-full">
-      <label className="block text-sm font-medium text-gray-700 mb-2">
+      <label className="block text-sm font-medium text-black mb-2">
         Type or paste your text here
       </label>
       <textarea
@@ -30,16 +30,16 @@ export default function TextCounter() {
       
       <div className="mt-6 grid grid-cols-3 gap-4">
         <div className="border border-gray-200 rounded-lg p-4">
-          <p className="text-sm font-medium text-gray-700">Words</p>
-          <p className="text-2xl font-bold text-gray-800">{countWords()}</p>
+          <p className="text-sm font-medium text-black">Words</p>
+          <p className="text-2xl font-bold text-black">{countWords()}</p>
         </div>
         <div className="border border-gray-200 rounded-lg p-4">
-          <p className="text-sm font-medium text-gray-700">Characters</p>
-          <p className="text-2xl font-bold text-gray-800">{countCharacters()}</p>
+          <p className="text-sm font-medium text-black">Characters</p>
+          <p className="text-2xl font-bold text-black">{countCharacters()}</p>
         </div>
         <div className="border border-gray-200 rounded-lg p-4">
-          <p className="text-sm font-medium text-gray-700">Spaces</p>
-          <p className="text-2xl font-bold text-gray-800">{countSpaces()}</p>
+          <p className="text-sm font-medium text-black">Spaces</p>
+          <p className="text-2xl font-bold text-black">{countSpaces()}</p>
         </div>
       </div>
     </div>

--- a/src/components/TokenProductionRateDemo.jsx
+++ b/src/components/TokenProductionRateDemo.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 const loremWords = [
   'Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing', 'elit',
@@ -110,14 +112,14 @@ export default function TokenProductionRateDemo() {
   const progress = tokens.length > 0 ? ((tokensGenerated / tokens.length) * 100).toFixed(1) : 0;
 
   return (
-    <div className="font-mono text-black space-y-8">
+    <div className="space-y-8">
       <div className="text-center">
-        <h2 className="text-2xl font-bold border-b-2 border-black pb-4">Token Production Rate Demo</h2>
+        <h2 className="text-2xl font-bold text-gray-800">Token Production Rate Demo</h2>
       </div>
 
-      <div className="border-2 border-black p-6 bg-gray-50">
-        <h3 className="font-bold mb-4">📖 Human Reading Speed Reference</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+      <Card className="bg-gray-50">
+        <h3 className="font-semibold mb-4">📖 Human Reading Speed Reference</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700">
           <div>
             <p className="mb-1"><strong>Average Reading Speed:</strong> 200-300 words/minute</p>
             <p className="mb-1"><strong>Speed Readers:</strong> 400-700 words/minute</p>
@@ -129,9 +131,9 @@ export default function TokenProductionRateDemo() {
             <p><strong>Beyond Human:</strong> 20+ tokens/sec</p>
           </div>
         </div>
-      </div>
+      </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 border-2 border-black p-6">
+      <Card className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
           <label htmlFor="textLength" className="block text-xs font-bold uppercase tracking-wide mb-2">
             Text Length: <span>{textLength}</span> words
@@ -162,54 +164,40 @@ export default function TokenProductionRateDemo() {
             className="w-full"
           />
         </div>
-      </div>
-
+      </Card>
       <div className="flex justify-center flex-wrap gap-4">
-        <button
-          className="px-6 py-2 border-2 border-black bg-black text-white font-bold uppercase tracking-wide hover:bg-white hover:text-black disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={startGeneration}
-          disabled={isGenerating}
-        >
-          Start
-        </button>
-        <button
-          className="px-6 py-2 border-2 border-black font-bold uppercase tracking-wide hover:bg-black hover:text-white disabled:opacity-50"
-          onClick={stopGeneration}
-          disabled={!isGenerating}
-        >
+        <Button onClick={startGeneration} disabled={isGenerating}>Start</Button>
+        <Button onClick={stopGeneration} disabled={!isGenerating} className="bg-white text-black border border-black hover:bg-gray-100">
           Stop
-        </button>
-        <button
-          className="px-6 py-2 border-2 border-black font-bold uppercase tracking-wide hover:bg-black hover:text-white"
-          onClick={resetDemo}
-        >
+        </Button>
+        <Button onClick={resetDemo} className="bg-white text-black border border-black hover:bg-gray-100">
           Reset
-        </button>
+        </Button>
       </div>
 
-      <div className="bg-black text-white p-6 border-2 border-black min-h-[300px] text-sm leading-relaxed overflow-y-auto">
+      <Card className="min-h-[300px] text-sm leading-relaxed overflow-y-auto bg-gray-50">
         {outputTokens.map((t, i) => (
           <span key={i}>{(i > 0 ? ' ' : '') + t}</span>
         ))}
-        {isGenerating && <span className="bg-white text-black px-1 ml-1 animate-pulse">|</span>}
-      </div>
+        {isGenerating && <span className="text-black px-1 ml-1 animate-pulse">|</span>}
+      </Card>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{tokensGenerated}</div>
-          <div className="text-xs uppercase tracking-wide">Tokens Generated</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Tokens Generated</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{currentSpeed}</div>
-          <div className="text-xs uppercase tracking-wide">Current Speed (T/S)</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Current Speed (T/S)</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{timeElapsed.toFixed(1)}s</div>
-          <div className="text-xs uppercase tracking-wide">Time Elapsed</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Time Elapsed</div>
         </div>
-        <div className="border-2 border-black p-4 text-center">
+        <div className="border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-xl font-bold mb-1">{progress}%</div>
-          <div className="text-xs uppercase tracking-wide">Progress</div>
+          <div className="text-xs uppercase tracking-wide text-gray-600">Progress</div>
         </div>
       </div>
     </div>

--- a/src/components/ocr/Footer.jsx
+++ b/src/components/ocr/Footer.jsx
@@ -6,8 +6,8 @@ export default function Footer() {
     <footer className="mt-16 text-center">
       <div className="border-t border-gray-200 pt-8">
         <div className="flex flex-wrap justify-center gap-8 mb-6">
-          <div className="flex items-start space-x-3 text-sm max-w-xs">
-            <Lock className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start space-x-3 text-sm max-w-xs">
+              <Lock className="w-5 h-5 text-black flex-shrink-0 mt-0.5" />
             <div>
               <div className="font-medium text-gray-900">Privacy First</div>
               <div className="text-gray-600">
@@ -16,8 +16,8 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="flex items-start space-x-3 text-sm max-w-xs">
-            <Cpu className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start space-x-3 text-sm max-w-xs">
+              <Cpu className="w-5 h-5 text-black flex-shrink-0 mt-0.5" />
             <div>
               <div className="font-medium text-gray-900">Advanced OCR</div>
               <div className="text-gray-600">
@@ -26,8 +26,8 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="flex items-start space-x-3 text-sm max-w-xs">
-            <Info className="w-5 h-5 text-purple-600 flex-shrink-0 mt-0.5" />
+            <div className="flex items-start space-x-3 text-sm max-w-xs">
+              <Info className="w-5 h-5 text-black flex-shrink-0 mt-0.5" />
             <div>
               <div className="font-medium text-gray-900">Searchable Output</div>
               <div className="text-gray-600">

--- a/src/components/ocr/Header.jsx
+++ b/src/components/ocr/Header.jsx
@@ -4,8 +4,8 @@ import { ScanText, Shield, Zap } from 'lucide-react';
 export default function Header() {
   return (
     <header className="text-center mb-12">
-      <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-6">
-        <ScanText className="w-8 h-8 text-blue-600" />
+      <div className="inline-flex items-center justify-center w-16 h-16 bg-gray-100 rounded-full mb-6">
+        <ScanText className="w-8 h-8 text-black" />
       </div>
       <h1 className="text-4xl font-bold text-gray-900 mb-4">Document OCR Processor</h1>
       <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
@@ -14,15 +14,15 @@ export default function Header() {
       </p>
       <div className="flex flex-wrap justify-center gap-8 text-sm">
         <div className="flex items-center space-x-2 text-gray-700">
-          <Shield className="w-5 h-5 text-green-600" />
+          <Shield className="w-5 h-5 text-black" />
           <span>100% Client-Side Processing</span>
         </div>
         <div className="flex items-center space-x-2 text-gray-700">
-          <Zap className="w-5 h-5 text-blue-600" />
+          <Zap className="w-5 h-5 text-black" />
           <span>Instant Results</span>
         </div>
         <div className="flex items-center space-x-2 text-gray-700">
-          <ScanText className="w-5 h-5 text-purple-600" />
+          <ScanText className="w-5 h-5 text-black" />
           <span>Searchable PDFs</span>
         </div>
       </div>

--- a/src/components/ocr/LanguageSelector.jsx
+++ b/src/components/ocr/LanguageSelector.jsx
@@ -7,7 +7,7 @@ export default function LanguageSelector({ selectedLanguage, onLanguageChange, d
     <div className="relative">
       <label htmlFor="language-select" className="block text-sm font-medium text-gray-700 mb-2">
         <div className="flex items-center space-x-2">
-          <Globe className="w-4 h-4 text-blue-600" />
+          <Globe className="w-4 h-4 text-black" />
           <span>Document Language</span>
         </div>
       </label>
@@ -19,7 +19,7 @@ export default function LanguageSelector({ selectedLanguage, onLanguageChange, d
           disabled={disabled}
           className={`
             w-full appearance-none bg-white border border-gray-300 rounded-lg px-4 py-3 pr-10
-            text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
+            text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-black focus:border-black
             transition-colors duration-200
             ${disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'hover:border-gray-400'}
           `}

--- a/src/components/ocr/OcrTool.jsx
+++ b/src/components/ocr/OcrTool.jsx
@@ -103,7 +103,7 @@ export default function OcrTool() {
   const acceptedFormats = FileValidator.getAcceptedFormats().split(',');
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+    <div className="min-h-screen bg-white">
       <div className="container mx-auto px-4 py-8">
         <Header />
         <main className="flex flex-col items-center space-y-8">

--- a/src/components/ocr/ProcessingIndicator.jsx
+++ b/src/components/ocr/ProcessingIndicator.jsx
@@ -30,26 +30,8 @@ export default function ProcessingIndicator({ files, onDownload, onRemove }) {
         return Loader;
     }
   };
-  const getStatusColor = (status) => {
-    switch (status) {
-      case 'completed':
-        return 'text-green-600';
-      case 'error':
-        return 'text-red-600';
-      default:
-        return 'text-blue-600';
-    }
-  };
-  const getBackgroundColor = (status) => {
-    switch (status) {
-      case 'completed':
-        return 'bg-green-50 border-green-200';
-      case 'error':
-        return 'bg-red-50 border-red-200';
-      default:
-        return 'bg-blue-50 border-blue-200';
-    }
-  };
+  const getStatusColor = () => 'text-black';
+  const getBackgroundColor = () => 'bg-gray-50 border-gray-200';
   return (
     <div className="w-full max-w-4xl mx-auto mt-8">
       <h3 className="text-lg font-semibold text-gray-900 mb-4">
@@ -104,7 +86,7 @@ export default function ProcessingIndicator({ files, onDownload, onRemove }) {
                       <div className="mt-2">
                         <div className="w-full bg-gray-200 rounded-full h-2">
                           <div
-                            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                            className="bg-black h-2 rounded-full transition-all duration-300"
                             style={{ width: `${file.progress}%` }}
                           />
                         </div>
@@ -127,7 +109,7 @@ export default function ProcessingIndicator({ files, onDownload, onRemove }) {
                     {file.status === 'completed' && (
                       <button
                         onClick={() => onDownload(file)}
-                        className="p-2 text-green-600 hover:bg-green-100 rounded-full transition-colors duration-200"
+                        className="p-2 text-black hover:bg-gray-100 rounded-full transition-colors duration-200"
                         title="Download processed file"
                       >
                         <Download className="w-5 h-5" />
@@ -136,7 +118,7 @@ export default function ProcessingIndicator({ files, onDownload, onRemove }) {
                     {file.status === 'completed' && hasPageTexts && (
                       <button
                         onClick={() => toggleExpanded(file.id)}
-                        className="p-2 text-blue-600 hover:bg-blue-100 rounded-full transition-colors duration-200"
+                        className="p-2 text-black hover:bg-gray-100 rounded-full transition-colors duration-200"
                         title={isExpanded ? 'Hide page text' : 'Show page text'}
                       >
                         {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}

--- a/src/components/ocr/UploadZone.jsx
+++ b/src/components/ocr/UploadZone.jsx
@@ -110,7 +110,7 @@ export default function UploadZone({ onFilesSelected, isProcessing, acceptedForm
       <div
         className={`
           relative border-2 border-dashed rounded-xl p-12 text-center transition-all duration-300 cursor-pointer
-          ${isDragActive ? 'border-blue-500 bg-blue-50 scale-105' : 'border-gray-300 hover:border-gray-400'}
+          ${isDragActive ? 'border-black bg-gray-50 scale-105' : 'border-gray-300 hover:border-gray-400'}
           ${isProcessing ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-50'}
         `}
         onDragEnter={handleDragIn}
@@ -136,11 +136,11 @@ export default function UploadZone({ onFilesSelected, isProcessing, acceptedForm
         <div className="flex flex-col items-center space-y-4">
           <div className={`
             p-6 rounded-full transition-all duration-300
-            ${isDragActive ? 'bg-blue-100' : 'bg-gray-100'}
+            ${isDragActive ? 'bg-gray-100' : 'bg-gray-100'}
           `}>
             <Upload className={`
               w-12 h-12 transition-colors duration-300
-              ${isDragActive ? 'text-blue-600' : 'text-gray-600'}
+              ${isDragActive ? 'text-black' : 'text-gray-600'}
             `} />
           </div>
           <div className="space-y-2">
@@ -148,7 +148,7 @@ export default function UploadZone({ onFilesSelected, isProcessing, acceptedForm
               {isDragActive ? 'Drop files here' : 'Upload Documents for OCR'}
             </h3>
             <p className="text-gray-600">
-              Drag and drop files here, or <span className="text-blue-600 font-medium">click to browse</span>
+              Drag and drop files here, or <span className="text-black font-medium">click to browse</span>
             </p>
           </div>
           <div className="flex items-center space-x-6 text-sm text-gray-500">
@@ -167,8 +167,8 @@ export default function UploadZone({ onFilesSelected, isProcessing, acceptedForm
           </div>
         </div>
         {isDragActive && (
-          <div className="absolute inset-0 rounded-xl bg-blue-500 bg-opacity-10 flex items-center justify-center">
-            <div className="text-blue-600 font-semibold text-lg">Release to upload files</div>
+          <div className="absolute inset-0 rounded-xl bg-black bg-opacity-10 flex items-center justify-center">
+            <div className="text-black font-semibold text-lg">Release to upload files</div>
           </div>
         )}
       </div>

--- a/src/components/stakeholder/StakeholderTool.jsx
+++ b/src/components/stakeholder/StakeholderTool.jsx
@@ -68,14 +68,14 @@ export default function StakeholderTool() {
         <button
           type="button"
           onClick={() => addCard(1)}
-          className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg shadow-md transition-colors"
+          className="btn shadow-md"
         >
           +
         </button>
         <button
           type="button"
           onClick={handleExport}
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg shadow-md transition-colors"
+          className="btn shadow-md"
         >
           Export as PNG
         </button>

--- a/src/components/stakeholder/stakeholder.css
+++ b/src/components/stakeholder/stakeholder.css
@@ -1,6 +1,6 @@
 .app-container {
-  background-color: #f9fafb;
-  color: #111827;
+  background-color: #ffffff;
+  color: #000000;
   height: 100%;
   width: 100%;
   display: flex;
@@ -18,7 +18,7 @@
   bottom: 1rem;
   right: 1rem;
   padding: 0.5rem 1.5rem;
-  background-color: #16a34a;
+  background-color: #000000;
   border-radius: 6px;
   font-weight: 600;
   color: white;
@@ -28,7 +28,7 @@
 }
 
 .export-button:hover {
-  background-color: #22c55e;
+  background-color: #333333;
 }
 
 .matrix-row {
@@ -153,9 +153,9 @@
   background-clip: padding-box;
 }
 
-.draggable-box {
-  background-color: #3b82f6;
-  color: white;
+  .draggable-box {
+    background-color: #000000;
+    color: white;
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -262,8 +262,8 @@
   width: 3rem;
   height: 3rem;
   border-radius: 9999px;
-  background-color: #3b82f6;
-  color: white;
+    background-color: #000000;
+    color: white;
   font-size: 1.5rem;
   display: flex;
   align-items: center;
@@ -274,5 +274,5 @@
 }
 
 .add-card-button:hover {
-  background-color: #60a5fa;
+  background-color: #333333;
 }

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Button({ className, ...props }) {
+  return (
+    <button
+      className={clsx('btn', className)}
+      {...props}
+    />
+  )
+}

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Card({ className, ...props }) {
+  return (
+    <div
+      className={clsx('card', className)}
+      {...props}
+    />
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply font-sans text-black bg-white;
+  }
+}
+
+@layer components {
+  .btn {
+    @apply px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  .card {
+    @apply bg-white text-black border border-black rounded-xl p-6 shadow-card;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,23 @@
 /** @type {import('tailwindcss').Config} */
+import colors from 'tailwindcss/colors'
+
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        neutral: colors.gray,
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+      boxShadow: {
+        card: '0 1px 2px rgba(0,0,0,0.05)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- establish global black and white theme with shared button and card classes
- strip tool-specific colors so components reuse the monochrome styles
- drop custom primary palette from Tailwind config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689277a18d28832bbdd400e2ea9b6e31