### PR TITLE
Add text-to-binary converter tool

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import StakeholderTool from './components/stakeholder/StakeholderTool';
 import OcrTool from './components/ocr/OcrTool';
 import RAGTokenCalculator from './components/RAGTokenCalculator';
 import TokenProductionRateDemo from './components/TokenProductionRateDemo';
+import TextConverter from './components/TextConverter';
 
 
 function App() {
@@ -42,6 +43,8 @@ function App() {
                   ? 'HEIC to JPG Converter'
                   : activeTool === 'textcounter'
                   ? 'Text Counter'
+                  : activeTool === 'converter'
+                  ? 'Text Converter'
                   : activeTool === 'pomodoro'
                   ? 'Pomodoro Timer'
                   : activeTool === 'ipaddress'
@@ -68,6 +71,8 @@ function App() {
                 <HeicToJpgConverter />
               ) : activeTool === 'textcounter' ? (
                 <TextCounter />
+              ) : activeTool === 'converter' ? (
+                <TextConverter />
               ) : activeTool === 'pomodoro' ? (
                 <PomodoroTimer />
               ) : activeTool === 'ipaddress' ? (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -8,7 +8,8 @@ import {
   Globe,
   ScanText,
   Calculator,
-  Activity
+  Activity,
+  RefreshCw
 } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -52,6 +53,19 @@ function Sidebar({ activeTool, setActiveTool }) {
               <PenLine className="w-5 h-5" />
               <span className="font-medium">Text Counter</span>
             </button>
+            <button
+              className={clsx(
+                "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
+                activeTool === 'converter'
+                  ? "bg-gray-900 text-white hover:bg-gray-800"
+                  : "text-gray-600 hover:bg-gray-50",
+              )}
+              onClick={() => setActiveTool('converter')}
+            >
+              <RefreshCw className="w-5 h-5" />
+              <span className="font-medium">Converter</span>
+            </button>
+
             
             <button
               className={clsx(

--- a/src/components/TextConverter.jsx
+++ b/src/components/TextConverter.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+
+function textToBinary(text) {
+  return text
+    .split('')
+    .map((char) => char.charCodeAt(0).toString(2).padStart(8, '0'))
+    .join(' ');
+}
+
+export default function TextConverter() {
+  const [input, setInput] = useState('');
+  const [mode, setMode] = useState('binary');
+  const [output, setOutput] = useState('');
+
+  useEffect(() => {
+    if (mode === 'binary') {
+      setOutput(textToBinary(input));
+    } else {
+      setOutput('');
+    }
+  }, [input, mode]);
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Input</label>
+        <textarea
+          className="w-full min-h-[8rem] p-4 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+          placeholder="Type or paste your text here..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Convert to</label>
+        <select
+          className="w-full p-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+        >
+          <option value="binary">Binary</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Output</label>
+        <textarea
+          className="w-full min-h-[8rem] p-4 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+          placeholder="Converted text will appear here..."
+          value={output}
+          readOnly
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add converter component to transform text input into binary
- expose converter via sidebar navigation and app routing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cde63245c832bbda72fc27ce89daf