### PR TITLE
feat: add link saver tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A collection of useful web-based tools including a HEIC to JPG converter, text c
 - 🌐 Display your current public IP address
 - 🔄 Refresh the value with a single click
 
+### Link Saver
+- 🔖 Save links with descriptions and tags
+- 💾 Stores data locally in your browser
+
 ## Technology Stack
 
 - React.js for the UI

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import StakeholderTool from './components/stakeholder/StakeholderTool';
 import OcrTool from './components/ocr/OcrTool';
 import RAGTokenCalculator from './components/RAGTokenCalculator';
 import TokenProductionRateDemo from './components/TokenProductionRateDemo';
+import LinkSaver from './components/LinkSaver';
 
 
 function App() {
@@ -54,6 +55,8 @@ function App() {
                   ? 'Document OCR'
                   : activeTool === 'tokenrate'
                   ? 'Token Production Rate Demo'
+                  : activeTool === 'linksaver'
+                  ? 'Link Saver'
                   : 'coming soon ..'}
               </h1>
               <div className="flex items-center space-x-4">
@@ -80,6 +83,8 @@ function App() {
                 <OcrTool />
               ) : activeTool === 'tokenrate' ? (
                 <TokenProductionRateDemo />
+              ) : activeTool === 'linksaver' ? (
+                <LinkSaver />
               ) : activeTool === 'comingsoon' ? (
                 <div className="text-center">
                   <button

--- a/src/components/LinkSaver.jsx
+++ b/src/components/LinkSaver.jsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+
+function LinkSaver() {
+  const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [tag, setTag] = useState('');
+  const [links, setLinks] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('savedLinks');
+    if (stored) {
+      try {
+        setLinks(JSON.parse(stored));
+      } catch (e) {
+        console.error('Failed to parse stored links', e);
+      }
+    }
+  }, []);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!url.trim()) return;
+
+    const newEntry = {
+      id: Date.now(),
+      url: url.trim(),
+      description: description.trim(),
+      tag: tag.trim(),
+    };
+
+    const updated = [...links, newEntry];
+    setLinks(updated);
+    localStorage.setItem('savedLinks', JSON.stringify(updated));
+
+    setUrl('');
+    setDescription('');
+    setTag('');
+  };
+
+  const handleDelete = (id) => {
+    const updated = links.filter((item) => item.id !== id);
+    setLinks(updated);
+    localStorage.setItem('savedLinks', JSON.stringify(updated));
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Link"
+          className="w-full border border-gray-300 rounded px-3 py-2"
+          required
+        />
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          className="w-full border border-gray-300 rounded px-3 py-2"
+        />
+        <input
+          type="text"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          placeholder="Tag"
+          className="w-full border border-gray-300 rounded px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
+        >
+          Save
+        </button>
+      </form>
+
+      <ul className="mt-6 space-y-4">
+        {links.map((item) => (
+          <li
+            key={item.id}
+            className="border border-gray-200 rounded p-4 space-y-1"
+          >
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline break-all"
+            >
+              {item.url}
+            </a>
+            {item.description && (
+              <p className="text-gray-700">{item.description}</p>
+            )}
+            {item.tag && (
+              <span className="text-sm text-gray-500">#{item.tag}</span>
+            )}
+            <div>
+              <button
+                onClick={() => handleDelete(item.id)}
+                className="text-sm text-red-500 hover:underline mt-2"
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default LinkSaver;
+

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -8,7 +8,8 @@ import {
   Globe,
   ScanText,
   Calculator,
-  Activity
+  Activity,
+  BookmarkPlus
 } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -118,8 +119,21 @@ function Sidebar({ activeTool, setActiveTool }) {
               <span className="font-medium">Token Rate Demo</span>
             </button>
 
+            <button
+              className={clsx(
+                "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
+                activeTool === 'linksaver'
+                  ? "bg-gray-900 text-white hover:bg-gray-800"
+                  : "text-gray-600 hover:bg-gray-50",
+              )}
+              onClick={() => setActiveTool('linksaver')}
+            >
+              <BookmarkPlus className="w-5 h-5" />
+              <span className="font-medium">Link Saver</span>
+            </button>
 
-            <button 
+
+            <button
               className={clsx(
                 "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
                 activeTool === 'comingsoon' 


### PR DESCRIPTION
## Summary
- add Link Saver component for storing links with descriptions and tags in local storage
- expose Link Saver via sidebar navigation and app routing
- document Link Saver in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cdf4b63d8832b8eb518e83c3752d7