### PR TITLE
feat: add text-binary switcher and clean sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import OcrTool from './components/ocr/OcrTool';
 import RAGTokenCalculator from './components/RAGTokenCalculator';
 import TokenProductionRateDemo from './components/TokenProductionRateDemo';
 import TextConverter from './components/TextConverter';
-import AsciiConverter from './components/AsciiConverter';
 
 
 function App() {
@@ -31,7 +30,7 @@ function App() {
             className={
               clsx(
                 'mx-auto',
-                activeTool === 'stakeholders' || activeTool === 'ragcalc' || activeTool === 'ascii'
+                activeTool === 'stakeholders' || activeTool === 'ragcalc'
                   ? 'w-full max-w-none'
                   : 'max-w-4xl'
               )
@@ -58,8 +57,6 @@ function App() {
                   ? 'Document OCR'
                   : activeTool === 'tokenrate'
                   ? 'Token Production Rate Demo'
-                  : activeTool === 'ascii'
-                  ? 'ASCII Art Converter'
                   : 'coming soon ..'}
               </h1>
               <div className="flex items-center space-x-4">
@@ -88,8 +85,6 @@ function App() {
                 <OcrTool />
               ) : activeTool === 'tokenrate' ? (
                 <TokenProductionRateDemo />
-              ) : activeTool === 'ascii' ? (
-                <AsciiConverter />
               ) : activeTool === 'comingsoon' ? (
                 <div className="text-center">
                   <button

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,8 +9,7 @@ import {
   ScanText,
   Calculator,
   Activity,
-  RefreshCw,
-  Terminal
+  RefreshCw
 } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -67,20 +66,6 @@ function Sidebar({ activeTool, setActiveTool }) {
               <span className="font-medium">Converter</span>
             </button>
 
-            <button
-              className={clsx(
-                "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
-                activeTool === 'ascii'
-                  ? "bg-gray-900 text-white hover:bg-gray-800"
-                  : "text-gray-600 hover:bg-gray-50",
-              )}
-              onClick={() => setActiveTool('ascii')}
-            >
-              <Terminal className="w-5 h-5" />
-              <span className="font-medium">ASCII Converter</span>
-            </button>
-
-            
             <button
               className={clsx(
                 "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",

--- a/src/components/TextConverter.jsx
+++ b/src/components/TextConverter.jsx
@@ -7,44 +7,67 @@ function textToBinary(text) {
     .join(' ');
 }
 
+function binaryToText(binary) {
+  return binary
+    .trim()
+    .split(/\s+/)
+    .map((bin) => {
+      const code = parseInt(bin, 2);
+      return isNaN(code) ? '' : String.fromCharCode(code);
+    })
+    .join('');
+}
+
 export default function TextConverter() {
   const [input, setInput] = useState('');
-  const [mode, setMode] = useState('binary');
+  const [mode, setMode] = useState('text-to-binary');
   const [output, setOutput] = useState('');
 
   useEffect(() => {
-    if (mode === 'binary') {
+    if (mode === 'text-to-binary') {
       setOutput(textToBinary(input));
     } else {
-      setOutput('');
+      setOutput(binaryToText(input));
     }
   }, [input, mode]);
+
+  const handleSwitch = () => {
+    const newMode = mode === 'text-to-binary' ? 'binary-to-text' : 'text-to-binary';
+    setMode(newMode);
+    setInput(output);
+  };
 
   return (
     <div className="flex flex-col space-y-4">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">Input</label>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Input ({mode === 'text-to-binary' ? 'Text' : 'Binary'})
+        </label>
         <textarea
           className="w-full min-h-[8rem] p-4 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-          placeholder="Type or paste your text here..."
+          placeholder={
+            mode === 'text-to-binary'
+              ? 'Type or paste your text here...'
+              : 'Enter binary, e.g. 01001000 01100101'
+          }
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">Convert to</label>
-        <select
-          className="w-full p-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-          value={mode}
-          onChange={(e) => setMode(e.target.value)}
+      <div className="flex justify-center">
+        <button
+          className="px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
+          onClick={handleSwitch}
         >
-          <option value="binary">Binary</option>
-        </select>
+          Switch to {mode === 'text-to-binary' ? 'Binary to Text' : 'Text to Binary'}
+        </button>
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">Output</label>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Output ({mode === 'text-to-binary' ? 'Binary' : 'Text'})
+        </label>
         <textarea
           className="w-full min-h-[8rem] p-4 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-transparent"
           placeholder="Converted text will appear here..."


### PR DESCRIPTION
## Summary
- remove ASCII converter from navigation sidebar
- allow switching between text↔binary in converter tool

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cf0bc58dc832ba43dfc867ef8b0a8