### PR TITLE
Fix mailto generator encoding

### DIFF
--- a/src/components/MailtoLinkGenerator.jsx
+++ b/src/components/MailtoLinkGenerator.jsx
@@ -8,33 +8,39 @@ const initialState = {
   body: '',
 };
 
-const generateMailto = ({ to, cc, bcc, subject, body }) => {
-  const baseRecipients = to
+const splitEmails = (value) =>
+  value
     .split(',')
     .map((recipient) => recipient.trim())
-    .filter(Boolean)
-    .map((recipient) => encodeURIComponent(recipient))
-    .join(',');
+    .filter(Boolean);
 
-  const params = new URLSearchParams();
+const encodeEmailList = (value) => splitEmails(value).map(encodeURIComponent).join(',');
+
+const encodeQueryValue = (value) =>
+  encodeURIComponent(value.replace(/\r?\n/g, '\r\n'));
+
+const generateMailto = ({ to, cc, bcc, subject, body }) => {
+  const baseRecipients = encodeEmailList(to);
+
+  const queryParts = [];
 
   if (cc.trim()) {
-    params.set('cc', cc.trim());
+    queryParts.push(`cc=${encodeEmailList(cc)}`);
   }
 
   if (bcc.trim()) {
-    params.set('bcc', bcc.trim());
+    queryParts.push(`bcc=${encodeEmailList(bcc)}`);
   }
 
   if (subject.trim()) {
-    params.set('subject', subject.trim());
+    queryParts.push(`subject=${encodeQueryValue(subject.trim())}`);
   }
 
   if (body.trim()) {
-    params.set('body', body);
+    queryParts.push(`body=${encodeQueryValue(body)}`);
   }
 
-  const query = params.toString();
+  const query = queryParts.join('&');
   return `mailto:${baseRecipients}${query ? `?${query}` : ''}`;
 };
 


### PR DESCRIPTION
## Summary
- normalize line breaks and percent-encode fields before composing mailto links
- reuse shared helpers so address fields are trimmed and encoded consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d06bbdbcd0832b96503e45fd9fae95