### PR TITLE
Add QR code generator tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^0.294.0",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^4.0.379",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.3.8",
@@ -2592,6 +2593,15 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -9,20 +9,21 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "clsx": "^2.0.0",
+    "file-saver": "^2.0.5",
     "heic2any": "^0.0.4",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.294.0",
+    "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^4.0.379",
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.3.8",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/modifiers": "^9.0.0",
-    "file-saver": "^2.0.5",
-    "html-to-image": "^1.11.13",
-    "zustand": "^4.5.2",
     "tesseract.js": "^5.0.4",
-    "pdf-lib": "^1.17.1",
-    "pdfjs-dist": "^4.0.379"
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import TokenProductionRateDemo from './components/TokenProductionRateDemo';
 import TextConverter from './components/TextConverter';
 import ElasticSearchRamCalculator from './components/ElasticSearchRamCalculator';
 import MailtoLinkGenerator from './components/MailtoLinkGenerator';
+import QrCodeGenerator from './components/QrCodeGenerator';
 
 
 function App() {
@@ -63,6 +64,8 @@ function App() {
                   ? 'ES RAM Calculator'
                   : activeTool === 'mailtolink'
                   ? 'Mailto Link Generator'
+                  : activeTool === 'qrcode'
+                  ? 'QR Code Generator'
                   : 'coming soon ..'}
               </h1>
               <div className="flex items-center space-x-4">
@@ -95,6 +98,8 @@ function App() {
                 <ElasticSearchRamCalculator />
               ) : activeTool === 'mailtolink' ? (
                 <MailtoLinkGenerator />
+              ) : activeTool === 'qrcode' ? (
+                <QrCodeGenerator />
               ) : activeTool === 'comingsoon' ? (
                 <div className="text-center">
                   <button

--- a/src/components/QrCodeGenerator.jsx
+++ b/src/components/QrCodeGenerator.jsx
@@ -1,0 +1,135 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
+
+const defaultUrls = [
+  'https://example.com',
+  'https://openai.com',
+];
+
+function sanitizeUrls(rawInput) {
+  return rawInput
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function validateUrl(url) {
+  try {
+    // The URL constructor will throw if it cannot parse the string.
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+const QrCodeGenerator = () => {
+  const [inputValue, setInputValue] = useState(defaultUrls.join('\n'));
+  const [urls, setUrls] = useState(defaultUrls);
+  const [invalidUrls, setInvalidUrls] = useState([]);
+  const qrCanvasRefs = useRef({});
+
+  const handleGenerate = () => {
+    const parsedUrls = sanitizeUrls(inputValue);
+    const invalid = parsedUrls.filter((item) => !validateUrl(item));
+
+    setInvalidUrls(invalid);
+
+    if (parsedUrls.length === 0 || invalid.length === parsedUrls.length) {
+      setUrls([]);
+      return;
+    }
+
+    setUrls(parsedUrls.filter((item) => validateUrl(item)));
+  };
+
+  const handleDownload = (index, url) => {
+    const canvas = qrCanvasRefs.current[index];
+
+    if (!canvas) {
+      return;
+    }
+
+    const dataUrl = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = `${url.replace(/[^a-z0-9]/gi, '_') || 'qr-code'}.png`;
+    link.click();
+  };
+
+  const helperText = useMemo(() => {
+    if (invalidUrls.length === 0) {
+      return 'Enter one URL per line to generate multiple QR codes.';
+    }
+
+    return `The following URLs could not be parsed: ${invalidUrls.join(', ')}`;
+  }, [invalidUrls]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">URLs</label>
+        <textarea
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          rows={4}
+          className="w-full border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-gray-900"
+          placeholder="https://example.com"
+        />
+        <div
+          className={
+            invalidUrls.length === 0
+              ? 'text-sm text-gray-500'
+              : 'text-sm text-red-600'
+          }
+        >
+          {helperText}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleGenerate}
+        className="px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
+      >
+        Generate QR Codes
+      </button>
+
+      {urls.length > 0 ? (
+        <div className="grid gap-6 md:grid-cols-2">
+          {urls.map((url, index) => (
+            <div
+              key={`${url}-${index}`}
+              className="border border-gray-200 rounded-lg p-4 space-y-4 flex flex-col items-center"
+            >
+              <QRCodeCanvas
+                value={url}
+                size={220}
+                level="H"
+                includeMargin
+                ref={(node) => {
+                  if (node) {
+                    qrCanvasRefs.current[index] = node.canvasRef.current;
+                  }
+                }}
+              />
+              <div className="text-sm text-gray-600 break-all text-center">{url}</div>
+              <button
+                type="button"
+                onClick={() => handleDownload(index, url)}
+                className="px-3 py-2 text-sm bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                Download PNG
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-gray-500 text-sm">No valid URLs to display yet.</div>
+      )}
+    </div>
+  );
+};
+
+export default QrCodeGenerator;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,8 @@ import {
   Calculator,
   Activity,
   RefreshCw,
-  Database
+  Database,
+  QrCode
 } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -104,6 +105,19 @@ function Sidebar({ activeTool, setActiveTool }) {
             >
               <Mail className="w-5 h-5" />
               <span className="font-medium">Mailto Link</span>
+            </button>
+
+            <button
+              className={clsx(
+                "w-full px-3 py-2 rounded-lg flex items-center space-x-3 transition-colors",
+                activeTool === 'qrcode'
+                  ? "bg-gray-900 text-white hover:bg-gray-800"
+                  : "text-gray-600 hover:bg-gray-50"
+              )}
+              onClick={() => setActiveTool('qrcode')}
+            >
+              <QrCode className="w-5 h-5" />
+              <span className="font-medium">QR Codes</span>
             </button>
 
             <button


### PR DESCRIPTION
## Summary
- add a QR code generator component that accepts multiple URLs and downloads PNG outputs
- register the tool in the app shell navigation and headings
- add the qrcode.react dependency for rendering QR canvases

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d2de88173c832b955684d365ab348d