### PR TITLE
Improve Ollama streaming for meeting prep and tone adjuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,14 @@ npm run preview
 
 The Tone Adjuster and Meeting Prep Assistant can call a locally running [Ollama](https://ollama.ai) instance for live rewrites and briefings.
 
-1. **Allow browser access** by setting the host and allowed origins when launching Ollama:
+1. **Allow browser access** by launching Ollama with the following command (paste it straight into your terminal):
 
    ```bash
-   OLLAMA_HOST=0.0.0.0:11434 \
-   OLLAMA_ORIGINS="http://localhost:5173" \
+   OLLAMA_HOST=0.0.0.0:11434 OLLAMA_ORIGINS="https://doyouknowmarc.github.io"
    ollama serve
    ```
-   
-   Copy Paste Example:
-   ```bash
-   OLLAMA_HOST=0.0.0.0:11434 OLLAMA_ORIGINS="https://doyouknowmarc.github.io" \
-   ollama serve
-   ```
-   
-   If you run the dev server on another port (or deploy the app), add that origin to the `OLLAMA_ORIGINS` list. You can also make the change permanent by adding the values to `~/.ollama/config`:
+
+   Swap the origin for your local dev URL (for example `http://localhost:5173`) if you are running the app from another host. You can also make the change permanent by adding the values to `~/.ollama/config`:
 
    ```toml
    [server]

--- a/src/utils/ollama.js
+++ b/src/utils/ollama.js
@@ -1,0 +1,96 @@
+export async function readOllamaStream(response, onDelta) {
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    const data = await response.json();
+    const final = (data.response || data.output || '').trim();
+    if (!final) {
+      throw new Error('Ollama returned an empty response.');
+    }
+    if (final) {
+      onDelta(final);
+    }
+    return final;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let collected = '';
+  let completed = false;
+
+  try {
+    while (!completed) {
+      const { value, done } = await reader.read();
+      const chunk = value ? decoder.decode(value, { stream: !done }) : '';
+      buffer += chunk;
+
+      if (done) {
+        buffer += decoder.decode();
+      }
+
+      const parts = buffer.split('\n');
+      buffer = parts.pop() ?? '';
+
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+
+        let payload;
+        try {
+          payload = JSON.parse(trimmed);
+        } catch (error) {
+          console.warn('Skipping malformed Ollama chunk', error);
+          continue;
+        }
+
+        if (payload.error) {
+          throw new Error(payload.error);
+        }
+
+        const delta = payload.response || payload.output || '';
+        if (delta) {
+          collected += delta;
+          onDelta(delta);
+        }
+
+        if (payload.done) {
+          completed = true;
+        }
+      }
+
+      if (done) {
+        break;
+      }
+    }
+
+    if (buffer.trim()) {
+      try {
+        const payload = JSON.parse(buffer.trim());
+        if (payload.error) {
+          throw new Error(payload.error);
+        }
+        const delta = payload.response || payload.output || '';
+        if (delta) {
+          collected += delta;
+          onDelta(delta);
+        }
+      } catch (error) {
+        console.warn('Unable to parse trailing Ollama buffer', error);
+      }
+    }
+  } finally {
+    if (!completed) {
+      try {
+        await reader.cancel();
+      } catch (error) {
+        console.debug('Ollama stream cancellation warning', error);
+      }
+    }
+  }
+
+  const final = collected.trim();
+  if (!final) {
+    throw new Error('Ollama returned an empty response.');
+  }
+
+  return final;
+}


### PR DESCRIPTION
## Summary
- add a shared Ollama streaming utility and enable streamed responses in the Meeting Prep Assistant and Content Tone Adjuster
- refresh the in-app and README instructions with a copy/paste ready Ollama launch command and messaging that emphasises the streaming workflow
- expand the tone adjuster with a grammar-polish preset, better local preview guidance, and richer Ollama-focused UI tweaks including copy actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5b28b9b00832bb4792d1ac4962d7b