### PR TITLE
Improve responsive layouts for metrics and calculators

### DIFF
--- a/src/components/RAGTokenCalculator.jsx
+++ b/src/components/RAGTokenCalculator.jsx
@@ -122,13 +122,13 @@ const RAGTokenCalculator = () => {
   };
 
   return (
-    <div className=" p-6  min-h-screen">
+    <div className="p-4 sm:p-6 min-h-screen">
       <div className="mb-8 text-center">
         <div className="flex items-center justify-center gap-3 mb-4">
           <Calculator className="w-8 h-8 text-blue-600" />
-          <h1 className="text-3xl font-bold text-gray-800">RAG Pipeline Token & Cost Calculator</h1>
+          <h1 className="text-2xl font-bold text-gray-800 sm:text-3xl">RAG Pipeline Token & Cost Calculator</h1>
         </div>
-        <p className="text-gray-600 max-w-3xl mx-auto">
+        <p className="mx-auto max-w-3xl text-base text-gray-600 sm:text-lg">
           Calculate precise token usage and costs for each step of your RAG pipeline: retrieval, re-ranking, and generation.
         </p>
       </div>
@@ -136,7 +136,7 @@ const RAGTokenCalculator = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <div className="rounded-xl bg-white p-6 shadow-lg">
             <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
               <Layers className="w-5 h-5 text-blue-600" />
               Scenario
@@ -342,14 +342,14 @@ const RAGTokenCalculator = () => {
         </div>
 
         <div className="lg:col-span-3 space-y-6">
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <div className="rounded-xl bg-white p-6 shadow-lg">
             <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
               <Zap className="w-5 h-5 text-green-600" />
               RAG Pipeline Steps & Costs
             </h2>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-blue-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
                   <div>
@@ -357,13 +357,13 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Initial query from user</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-blue-600">{calculations.step1_Query.toLocaleString()} tokens</div>
                   <div className="text-sm text-gray-500">No cost (stored)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-gray-600 text-white rounded-full flex items-center justify-center text-sm font-bold">2</div>
                   <div>
@@ -371,13 +371,13 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Vector search retrieves candidate chunks</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-gray-600">{calculations.step2_ChunksN.toLocaleString()} tokens</div>
                   <div className="text-sm text-gray-500">No cost (retrieval)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-yellow-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-yellow-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-yellow-600 text-white rounded-full flex items-center justify-center text-sm font-bold">3</div>
                   <div>
@@ -385,13 +385,13 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Query + All chunks + instructions</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-yellow-600">{calculations.step3_PromptRerank.toLocaleString()} tokens</div>
                   <div className="text-sm text-green-600 font-medium">${calculations.step3_Cost.toFixed(6)} (input)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-orange-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-orange-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-orange-600 text-white rounded-full flex items-center justify-center text-sm font-bold">4</div>
                   <div>
@@ -399,13 +399,13 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Top-K chunk IDs or rankings</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-orange-600">{calculations.step4_OutputRerank.toLocaleString()} tokens</div>
                   <div className="text-sm text-green-600 font-medium">${calculations.step4_Cost.toFixed(6)} (output)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-green-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-green-600 text-white rounded-full flex items-center justify-center text-sm font-bold">5</div>
                   <div>
@@ -413,13 +413,13 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Query + Top-K chunks + system prompt</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-green-600">{calculations.step5_PromptRAG.toLocaleString()} tokens</div>
                   <div className="text-sm text-green-600 font-medium">${calculations.step5_Cost.toFixed(6)} (input)</div>
                 </div>
               </div>
 
-              <div className="flex items-center justify-between p-4 bg-purple-50 rounded-lg">
+              <div className="flex flex-col gap-4 rounded-lg bg-purple-50 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-purple-600 text-white rounded-full flex items-center justify-center text-sm font-bold">6</div>
                   <div>
@@ -427,7 +427,7 @@ const RAGTokenCalculator = () => {
                     <div className="text-sm text-gray-600">Final generated response</div>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-left sm:text-right">
                   <div className="text-lg font-semibold text-purple-600">{calculations.step6_OutputAnswer.toLocaleString()} tokens</div>
                   <div className="text-sm text-green-600 font-medium">${calculations.step6_Cost.toFixed(6)} (output)</div>
                 </div>
@@ -435,8 +435,8 @@ const RAGTokenCalculator = () => {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white rounded-xl shadow-lg p-6">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div className="rounded-xl bg-white p-6 shadow-lg">
               <h3 className="text-lg font-semibold mb-4 text-gray-800">Token Summary</h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
@@ -454,7 +454,7 @@ const RAGTokenCalculator = () => {
               </div>
             </div>
 
-            <div className="bg-white rounded-xl shadow-lg p-6">
+            <div className="rounded-xl bg-white p-6 shadow-lg">
               <h3 className="text-lg font-semibold mb-4 text-gray-800 flex items-center gap-2">
                 <DollarSign className="w-5 h-5 text-green-600" />
                 Cost Breakdown
@@ -476,9 +476,9 @@ const RAGTokenCalculator = () => {
             </div>
           </div>
 
-          <div className="bg-white rounded-xl shadow-lg p-6">
+          <div className="rounded-xl bg-white p-6 shadow-lg">
             <h3 className="text-lg font-semibold mb-4 text-gray-800">Volume Projections</h3>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
               {[
                 { queries: 100, period: '100 queries' },
                 { queries: 1000, period: '1K queries' },

--- a/src/components/ScreenshotOptimizer.jsx
+++ b/src/components/ScreenshotOptimizer.jsx
@@ -214,17 +214,17 @@ function ScreenshotOptimizer() {
 
           <form onSubmit={handleUrlSubmit} className="space-y-3">
             <label className="block text-sm font-medium text-gray-700">Optimise from a URL</label>
-            <div className="flex rounded-lg shadow-sm overflow-hidden border border-gray-200">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <input
                 type="url"
                 placeholder="https://example.com/screenshot.png"
                 value={inputUrl}
                 onChange={(event) => setInputUrl(event.target.value)}
-                className="flex-1 px-3 py-2 text-sm focus:outline-none"
+                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
               />
               <button
                 type="submit"
-                className="px-4 bg-gray-900 text-white text-sm font-medium hover:bg-gray-800"
+                className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
               >
                 Fetch
               </button>
@@ -233,7 +233,7 @@ function ScreenshotOptimizer() {
 
           <div className="space-y-3">
             <p className="text-sm font-medium text-gray-700">Quality preset</p>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
               {qualityPresets.map((preset) => (
                 <button
                   key={preset.label}
@@ -272,7 +272,7 @@ function ScreenshotOptimizer() {
 
           <div className="space-y-3">
             <p className="text-sm font-medium text-gray-700">Output format</p>
-            <div className="flex space-x-2">
+            <div className="flex flex-wrap gap-2 sm:flex-nowrap">
               {formatOptions.map((option) => (
                 <button
                   key={option.mime}
@@ -312,7 +312,7 @@ function ScreenshotOptimizer() {
 
             {originalInfo && optimizedInfo && !error && (
               <div className="mt-4 space-y-4">
-                <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
                   <div>
                     <p className="text-xs uppercase text-gray-500">Original</p>
                     <p className="font-medium text-gray-900">{bytesToKb(originalInfo.size)}</p>

--- a/src/components/TextCounter.jsx
+++ b/src/components/TextCounter.jsx
@@ -28,18 +28,18 @@ export default function TextCounter() {
         onChange={(e) => setText(e.target.value)}
       />
       
-      <div className="mt-6 grid grid-cols-3 gap-4">
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div className="border border-gray-200 rounded-lg p-4">
           <p className="text-sm font-medium text-gray-700">Words</p>
-          <p className="text-2xl font-bold text-gray-800">{countWords()}</p>
+          <p className="text-xl font-bold text-gray-800 sm:text-2xl">{countWords()}</p>
         </div>
         <div className="border border-gray-200 rounded-lg p-4">
           <p className="text-sm font-medium text-gray-700">Characters</p>
-          <p className="text-2xl font-bold text-gray-800">{countCharacters()}</p>
+          <p className="text-xl font-bold text-gray-800 sm:text-2xl">{countCharacters()}</p>
         </div>
         <div className="border border-gray-200 rounded-lg p-4">
           <p className="text-sm font-medium text-gray-700">Spaces</p>
-          <p className="text-2xl font-bold text-gray-800">{countSpaces()}</p>
+          <p className="text-xl font-bold text-gray-800 sm:text-2xl">{countSpaces()}</p>
         </div>
       </div>
     </div>

--- a/src/components/TokenProductionRateDemo.jsx
+++ b/src/components/TokenProductionRateDemo.jsx
@@ -115,7 +115,7 @@ export default function TokenProductionRateDemo() {
         <h2 className="text-2xl font-bold border-b-2 border-black pb-4">Token Production Rate Demo</h2>
       </div>
 
-      <div className="border-2 border-black p-6 bg-gray-50">
+      <div className="border-2 border-black bg-gray-50 p-4 sm:p-6">
         <h3 className="font-bold mb-4">📖 Human Reading Speed Reference</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           <div>
@@ -131,7 +131,7 @@ export default function TokenProductionRateDemo() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 border-2 border-black p-6">
+      <div className="grid grid-cols-1 gap-8 border-2 border-black p-4 sm:p-6 md:grid-cols-2">
         <div>
           <label htmlFor="textLength" className="block text-xs font-bold uppercase tracking-wide mb-2">
             Text Length: <span>{textLength}</span> words
@@ -187,14 +187,14 @@ export default function TokenProductionRateDemo() {
         </button>
       </div>
 
-      <div className="bg-black text-white p-6 border-2 border-black min-h-[300px] text-sm leading-relaxed overflow-y-auto">
+      <div className="min-h-[300px] border-2 border-black bg-black p-4 text-sm leading-relaxed text-white overflow-y-auto sm:p-6">
         {outputTokens.map((t, i) => (
           <span key={i}>{(i > 0 ? ' ' : '') + t}</span>
         ))}
         {isGenerating && <span className="bg-white text-black px-1 ml-1 animate-pulse">|</span>}
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
         <div className="border-2 border-black p-4 text-center">
           <div className="text-xl font-bold mb-1">{tokensGenerated}</div>
           <div className="text-xs uppercase tracking-wide">Tokens Generated</div>


### PR DESCRIPTION
## Summary
- make the TextCounter metrics responsive with mobile-friendly typography
- update ScreenshotOptimizer controls and stats to stack cleanly on small screens
- refresh TokenProductionRateDemo and RAGTokenCalculator spacing and grids for better mobile layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5bf52c690832b85fdf8521e139b6b