### PR TITLE
Fix mobile sidebar placement and scrolling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,8 +41,8 @@ function App() {
         />
         <div
           className={clsx(
-            'relative ml-auto flex h-full w-64 max-w-full transform transition-transform duration-300',
-            isSidebarOpen ? 'translate-x-0' : 'translate-x-full'
+            'relative flex h-full w-64 max-w-full transform transition-transform duration-300',
+            isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
           )}
         >
           <Sidebar

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -38,7 +38,7 @@ function Sidebar({
   return (
     <div
       className={clsx(
-        'flex h-full w-64 flex-col border-r border-gray-200 bg-white',
+        'flex h-full w-64 flex-col overflow-y-auto border-r border-gray-200 bg-white',
         className
       )}
     >


### PR DESCRIPTION
## Summary
- slide the mobile sidebar in from the left instead of the right for consistency with desktop
- allow the sidebar content to scroll vertically so all tools are accessible on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9702e5bb4832bb717fb0624ccba51