### PR TITLE
Adjust layout widths for meeting prep and tone tools

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,11 +70,11 @@ function App() {
       <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
         <div
           className={clsx(
-            'mx-auto',
+            'mx-auto w-full',
             activeTool === 'stakeholders' || activeTool === 'ragcalc'
-              ? 'w-full max-w-none'
+              ? 'max-w-none'
               : activeTool === 'meetingprep' || activeTool === 'tone'
-              ? 'max-w-5xl'
+              ? 'max-w-6xl xl:max-w-7xl'
               : 'max-w-4xl'
           )}
         >


### PR DESCRIPTION
## Summary
- widen the meeting prep and tone adjuster layouts on large screens to prevent copy from clipping
- ensure the main content wrapper always expands to the available width for better responsive behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d97ad24198832b971f431afe9ce448