### PR TITLE
feat: Color Picker Tool (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ lerna-debug.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Playwright
+test-results/
+playwright-report/

--- a/e2e/issue-54.spec.js
+++ b/e2e/issue-54.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+const APP_URL = 'http://localhost:5173/tools/';
+
+// The app renders two Sidebar instances (mobile overlay + desktop fixed).
+// Both contain identical buttons — use :visible to target the rendered desktop sidebar.
+const sidebarButton = (page) =>
+  page.locator('button:has-text("Color Picker"):visible').first();
+
+test.describe('Issue #54: Color Picker Tool', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_URL);
+  });
+
+  test('color picker entry appears in sidebar', async ({ page }) => {
+    await expect(sidebarButton(page)).toBeVisible();
+  });
+
+  test('sidebar entry has a lucide icon (svg)', async ({ page }) => {
+    await expect(sidebarButton(page).locator('svg')).toBeVisible();
+  });
+
+  test('tool renders a native color input', async ({ page }) => {
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+  });
+
+  test('HEX, RGB, and HSL formats are all displayed simultaneously', async ({ page }) => {
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+
+    await expect(page.locator('input[aria-label="HEX value"]')).toBeVisible();
+    await expect(page.locator('input[aria-label="RGB value"]')).toBeVisible();
+    await expect(page.locator('input[aria-label="HSL value"]')).toBeVisible();
+  });
+
+  test('each format has a copy-to-clipboard button', async ({ page }) => {
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+
+    await expect(page.locator('button[aria-label="Copy HEX value"]')).toBeVisible();
+    await expect(page.locator('button[aria-label="Copy RGB value"]')).toBeVisible();
+    await expect(page.locator('button[aria-label="Copy HSL value"]')).toBeVisible();
+  });
+
+  test('copy button shows "Copied!" confirmation then reverts', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+
+    const copyHexButton = page.locator('button[aria-label="Copy HEX value"]');
+    await expect(copyHexButton).toContainText('Copy');
+    await copyHexButton.click();
+    await expect(copyHexButton).toContainText('Copied!');
+    // Confirmation auto-clears after ~1.5s — wait up to 3s for revert
+    await expect(copyHexButton).toContainText('Copy', { timeout: 3000 });
+  });
+
+  test('typing a valid HEX value updates RGB and HSL in real time', async ({ page }) => {
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+
+    const hexInput = page.locator('input[aria-label="HEX value"]');
+    await hexInput.fill('#ff0000');
+    await hexInput.press('Tab');
+
+    // Pure red: rgb(255, 0, 0) → hsl(0, 100%, 50%)
+    await expect(page.locator('input[aria-label="RGB value"]')).toHaveValue('rgb(255, 0, 0)');
+    await expect(page.locator('input[aria-label="HSL value"]')).toHaveValue('hsl(0, 100%, 50%)');
+  });
+
+  test('tool makes no external network requests', async ({ page }) => {
+    const externalRequests = [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (
+        !url.startsWith('http://localhost:') &&
+        !url.startsWith('https://localhost:') &&
+        !url.startsWith('ws://') &&
+        !url.startsWith('wss://')
+      ) {
+        externalRequests.push(url);
+      }
+    });
+
+    await sidebarButton(page).click();
+    await expect(page.locator('input[type="color"]')).toBeVisible();
+    await page.locator('input[aria-label="HEX value"]').fill('#00ff00');
+
+    expect(externalRequests).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.23.0",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1492,6 +1493,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5664,6 +5681,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:5173/tools/',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173/tools/',
+    reuseExistingServer: true,
+    timeout: 30000,
+  },
+});

--- a/src/components/ColorPickerTool.jsx
+++ b/src/components/ColorPickerTool.jsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+function hexToRgb(hex) {
+  const result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return { r: 0, g: 0, b: 0 };
+  return {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16),
+  };
+}
+
+function rgbToHsl(r, g, b) {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const delta = max - min;
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (delta !== 0) {
+    s = delta / (1 - Math.abs(2 * l - 1));
+    if (max === rNorm) {
+      h = ((gNorm - bNorm) / delta) % 6;
+    } else if (max === gNorm) {
+      h = (bNorm - rNorm) / delta + 2;
+    } else {
+      h = (rNorm - gNorm) / delta + 4;
+    }
+    h = Math.round(h * 60);
+    if (h < 0) h += 360;
+  }
+
+  return {
+    h,
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+const INITIAL_COLOR = '#3b82f6';
+
+export default function ColorPickerTool() {
+  const [hex, setHex] = useState(INITIAL_COLOR);
+  const [hexInput, setHexInput] = useState(INITIAL_COLOR);
+  const [copied, setCopied] = useState(null);
+
+  const { r, g, b } = hexToRgb(hex);
+  const { h, s, l } = rgbToHsl(r, g, b);
+
+  const rgbString = `rgb(${r}, ${g}, ${b})`;
+  const hslString = `hsl(${h}, ${s}%, ${l}%)`;
+
+  const handleColorWheelChange = useCallback((e) => {
+    const newHex = e.target.value;
+    setHex(newHex);
+    setHexInput(newHex);
+  }, []);
+
+  const handleHexInputChange = useCallback((e) => {
+    const value = e.target.value;
+    setHexInput(value);
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+      setHex(value.toLowerCase());
+    }
+  }, []);
+
+  const handleHexInputBlur = useCallback(() => {
+    if (!/^#[0-9a-fA-F]{6}$/.test(hexInput)) {
+      setHexInput(hex);
+    }
+  }, [hex, hexInput]);
+
+  const handleCopy = useCallback((format, value) => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(format);
+      setTimeout(() => setCopied(null), 1500);
+    });
+  }, []);
+
+  const formats = [
+    { key: 'hex', label: 'HEX', value: hex },
+    { key: 'rgb', label: 'RGB', value: rgbString },
+    { key: 'hsl', label: 'HSL', value: hslString },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col items-center gap-6">
+        <input
+          type="color"
+          value={hex}
+          onChange={handleColorWheelChange}
+          aria-label="Color picker"
+          className="h-24 w-48 cursor-pointer rounded-lg border border-gray-300 p-1"
+        />
+
+        <div
+          className="h-16 w-full max-w-md rounded-xl border border-gray-200 shadow-inner"
+          style={{ backgroundColor: hex }}
+          aria-label={`Color preview: ${hex}`}
+        />
+
+        <div className="w-full max-w-md space-y-3">
+          {formats.map(({ key, label, value }) => (
+            <div
+              key={key}
+              className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm"
+            >
+              <span className="w-10 shrink-0 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                {label}
+              </span>
+              {key === 'hex' ? (
+                <input
+                  type="text"
+                  value={hexInput}
+                  onChange={handleHexInputChange}
+                  onBlur={handleHexInputBlur}
+                  spellCheck={false}
+                  aria-label="HEX value"
+                  className="min-w-0 flex-1 bg-transparent font-mono text-sm text-gray-800 outline-none"
+                />
+              ) : (
+                <input
+                  type="text"
+                  value={value}
+                  readOnly
+                  spellCheck={false}
+                  aria-label={`${label} value`}
+                  className="min-w-0 flex-1 bg-transparent font-mono text-sm text-gray-800 outline-none"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => handleCopy(key, value)}
+                aria-label={`Copy ${label} value`}
+                className={`flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  copied === key
+                    ? 'bg-green-100 text-green-700'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {copied === key ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5" />
+                    Copy
+                  </>
+                )}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/toolRegistry.js
+++ b/src/toolRegistry.js
@@ -14,6 +14,7 @@ import {
   Mail,
   MapPin,
   PenLine,
+  Pipette,
   QrCode,
   RefreshCw,
   ScanText,
@@ -147,6 +148,13 @@ export const toolRegistry = [
     icon: Wand2,
     maxWidthClass: 'max-w-6xl xl:max-w-7xl',
     loader: () => import('./components/ContentToneAdjuster'),
+  }),
+  createTool({
+    id: 'colorpicker',
+    title: 'Color Picker',
+    sidebarLabel: 'Color Picker',
+    icon: Pipette,
+    loader: () => import('./components/ColorPickerTool'),
   }),
   createTool({
     id: 'qrcode',


### PR DESCRIPTION
## Summary

Closes #54

- New browser-based Color Picker tool added to the sidebar
- Users can pick a color visually and instantly see its value in HEX, RGB, and HSL formats simultaneously
- One-click copy-to-clipboard for each format with a brief "Copied!" confirmation
- Editable HEX input field syncs the color wheel and other formats in real time
- Entirely client-side — no external API calls or new runtime dependencies

## Changes

- `src/components/ColorPickerTool.jsx` — new self-contained tool component
- `src/toolRegistry.js` — registered `colorpicker` tool with `Pipette` icon
- `e2e/issue-54.spec.js` — Playwright e2e tests covering all 8 acceptance criteria
- `playwright.config.js` — Playwright config with `webServer` auto-start on port 5173
- `package.json` / `package-lock.json` — added `@playwright/test` dev dependency
- `.gitignore` — added `test-results/` and `playwright-report/` exclusions

## Test plan

- Playwright e2e tests added in `e2e/issue-54.spec.js` (8 tests, all passing)
- All acceptance criteria from the spec are covered by tests
- `npm run lint` passes (0 errors)
- `npm run test:run` (Vitest unit tests) passes (29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)